### PR TITLE
java.verify_ver does not verify java-1.8.0 (SOFTWARE-2212)

### DIFF
--- a/osgtest/library/java.py
+++ b/osgtest/library/java.py
@@ -34,14 +34,14 @@ def select_ver(java_type, version):
 def get_ver(java_type):
     """Find version of java that is currently selected in the alternatives"""
     current_java = _run_alternatives(java_type, '\n', 'find java version for selection')
-    return re.search(r'\+.*\/(.*-\d\.\d\.\d[^\/]*)\/', current_java, re.MULTILINE).group(1)
+    return re.search(r'\+.*\/(.*-\d+\.\d+\.\d+[^\/]*)\/', current_java, re.MULTILINE).group(1)
 
-def verify_ver(java_type, input_version):
+def verify_ver(java_type, expected_version):
     """Verify that the selected version of java is as expected."""
     command = (java_type, '-version')
     stdout, _, _ = core.check_system(command, 'verify %s version' % java_type)
     try:
-        runtime_version = re.match('java.*(\d\.\d\.\d)', stdout).group(1)
+        runtime_version = re.search('(\d+\.\d+\.\d+)', stdout.split('\n')[0]).group(1)
     except AttributeError:
         return False
-    return runtime_version in input_version
+    return runtime_version in expected_version


### PR DESCRIPTION
The output of `java -version` differs between java-1.7.0 and java-1.8.0. The former has its version number preceded by "java version" and the latter has its version preceded by "openjdk version". This commit changes `java.verify_ver()` to look for the version in the first line, ignoring any preceding text.

OpenJDK 1.7.0
```
# java -version
java version "1.7.0_95"
OpenJDK Runtime Environment (rhel-2.6.4.0.el7_2-x86_64 u95-b00)
OpenJDK 64-Bit Server VM (build 24.95-b01, mixed mode)
```

OpenJDK 1.8.0
```
# java -version
openjdk version "1.8.0_71"
OpenJDK Runtime Environment (build 1.8.0_71-b15)
OpenJDK 64-Bit Server VM (build 25.71-b15, mixed mode)
```
