### PR TITLE
osg-test should exit != 0 if tests fail (SOFTWARE-2306)

### DIFF
--- a/osg-test
+++ b/osg-test
@@ -189,7 +189,10 @@ def run_tests(a_argv):
         verb = 1
     test_suite = osgunittest.OSGTestLoader().loadTestsFromNames(a_argv)
     runner = osgunittest.OSGTextTestRunner(verbosity=verb)
-    runner.run(test_suite, exit_on_fail=core.options.exitonfail)
+    results = runner.run(test_suite, exit_on_fail=core.options.exitonfail)
+
+    if not results.wasSuccessful:
+        sys.exit(1)
 
 def wrap_up():
     core.end_log()


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2306

Tests look good other than errors that are being fixed in #7: http://vdt.cs.wisc.edu/tests/20160427-1413/results.html