### PR TITLE
Add option to osg-test that turns on SELinux (SOFTWARE-2270)

### DIFF
--- a/osg-test
+++ b/osg-test
@@ -30,6 +30,7 @@ def parse_command_line():
                 "packages": [],
                 "password": 'vdttest',
                 "printtest": True,
+                "selinux": False,
                 "securepass": False,
                 "skip_cleanup": False,
                 "skiptests": False,
@@ -129,6 +130,9 @@ def read_args():
     p.add_option('-s', '--securepass', action='store_true', dest='securepass',
                  help='Prompt for the password instead of specifying it in the command line.')
 
+    p.add_option('--selinux', action='store_true', dest='selinux',
+                 help='Set SELinux to \'enforcing\' mode')
+
     p.add_option('--update-release', action='store', type='string', dest='updaterelease', metavar='RELEASE',
                       help='osg RELEASE version to use when updating packages '
                       'specified with the -i flag.')
@@ -172,8 +176,11 @@ def discover_tests():
     test_files = ['osgtest.tests.' + test.strip() for test in test_sequence.readlines()]
     test_sequence.close()
     args = []
-    args.append('osgtest.tests.special_certs')
-    args.append('osgtest.tests.special_user') # always safe
+    # always safe
+    for test in ('osgtest.tests.special_certs',
+                 'osgtest.tests.special_user',
+                 'osgtest.tests.special_selinux'):
+        args.append(test)
     if len(core.options.packages) > 0:
         args.append('osgtest.tests.special_install')
     if not core.options.skiptests:

--- a/osg-test
+++ b/osg-test
@@ -39,35 +39,34 @@ def parse_command_line():
                 "updaterepos": [],
                 "username": 'vdttest',
                 "verbose": False,
-                "manualrun": False
-                }
+                "manualrun": False}
 
     # First pass through args to get config file
     config_option = read_args()
     (opts, args) = config_option.parse_args()
-        
+
     if len(args) != 0:
         config_option.error('unknown argument(s): %s' % ' '.join(args))
-    
+
     # Read the config file
     if opts.config:
         config_file = ConfigParser.RawConfigParser()
         try:
             config_file.read(opts.config)
-        except ConfigParser.ParsingError, e:
-            sys.stderr.write("Error while parsing: %s\n%s\n" % (opts.config, e))
+        except ConfigParser.ParsingError, exc:
+            sys.stderr.write("Error while parsing: %s\n%s\n" % (opts.config, exc))
             sys.stderr.write("Lines with options should not start with a space\n")
             sys.exit(1)
-            
+
         # Get union of config file values and defaults with the config values overriding any defaults
-        for key,value in config_file.items('Config'):
-            if key in defaults: 
+        for key, value in config_file.items('Config'):
+            if key in defaults:
                 if key == 'packages':
-                    defaults[key] = re.split(',\s*', value)
+                    defaults[key] = re.split(r',\s*', value)
                 elif key == 'extrarepos':
-                    defaults[key] = re.split(',\s*', value)
+                    defaults[key] = re.split(r',\s*', value)
                 elif key == 'updaterepos':
-                    defaults[key] = re.split(',\s*', value)
+                    defaults[key] = re.split(r',\s*', value)
                 elif key == 'timeout':
                     defaults[key] = config_file.getint('Config', key)
                 elif defaults[key] is False: # Grab values as booleans if we expect them to be
@@ -76,56 +75,56 @@ def parse_command_line():
                     defaults[key] = value
             else:
                 defaults[key] = value
-        
+
     # Read the rest of the command line options
     parser = read_args()
     parser.set_defaults(**defaults)
     (core.options, args) = parser.parse_args()
-    
+
     if core.options.updaterepos and not core.options.packages:
         parser.error('The -g (--update-repo) option requires -i (--install).')
 
 def read_args():
-    script_description='''Tests an OSG Software RPM installation.'''
+    script_description = '''Tests an OSG Software RPM installation.'''
     p = OptionParser(usage='usage: %prog [options]',
-                          version='%prog ##VERSION##',
-                          description=script_description)
+                     version='%prog ##VERSION##',
+                     description=script_description)
 
     p.add_option('-a', '--add-user', action='store_true', dest='adduser',
-                      help='Add and configure the test user account (see -u below)')
+                 help='Add and configure the test user account (see -u below)')
 
     p.add_option('-c', '--config', action='store', type='string', dest='config',
-                       help='Configuration file to use that specifies command-line options')
+                 help='Configuration file to use that specifies command-line options')
 
     p.add_option('-d', '--dump-output', action='store_true',
-                      dest='dumpout', help='After test output, print all command output')
-    
+                 dest='dumpout', help='After test output, print all command output')
+
     p.add_option('--dump-file', '--df', action='store', type='string', dest='dumpfile', metavar='DUMPFILE',
-                      help='Store all command output into DUMPFILE')
+                 help='Store all command output into DUMPFILE')
 
     p.add_option('--exit-on-fail', '-e', action='store_true', dest='exitonfail',
                  help='Stop tests on first failure and output the results')
 
     p.add_option('-i', '--install', action='append', dest='packages',
-                      metavar='PACKAGE',
-                      help='Install PACKAGE with yum before running tests')
+                 metavar='PACKAGE',
+                 help='Install PACKAGE with yum before running tests')
 
-    p.add_option('-g','--update-repo', action='append', type='string', dest='updaterepos', metavar='REPO',
-                      help='REPO to use when updating packages '
-                      'specified with the -i flag.')
+    p.add_option('-g', '--update-repo', action='append', type='string', dest='updaterepos', metavar='REPO',
+                 help='REPO to use when updating packages '
+                 'specified with the -i flag.')
 
     p.add_option('-m', '--manual-run', action='store_true', dest='manualrun',
-                      help='Speeds up osg-test in the case where it is '
-                      'run by hand. May not be suitable when running '
-                      'multiple instances of osg-test at once.')
-    
+                 help='Speeds up osg-test in the case where it is '
+                 'run by hand. May not be suitable when running '
+                 'multiple instances of osg-test at once.')
+
     p.add_option('-n', '--no-cleanup', action='store_true', dest='skip_cleanup',
-                       help='Skip clean-up steps after all tests are done')
+                 help='Skip clean-up steps after all tests are done')
 
     p.add_option('-p', '--password', action='store', type='string',
-                      dest='password',
-                      help='Password for the grid certificate of the test user '
-                      '(see -u below)')
+                 dest='password',
+                 help='Password for the grid certificate of the test user '
+                 '(see -u below)')
 
     p.add_option('-s', '--securepass', action='store_true', dest='securepass',
                  help='Prompt for the password instead of specifying it in the command line.')
@@ -134,32 +133,32 @@ def read_args():
                  help='Set SELinux to \'enforcing\' mode')
 
     p.add_option('--update-release', action='store', type='string', dest='updaterelease', metavar='RELEASE',
-                      help='osg RELEASE version to use when updating packages '
-                      'specified with the -i flag.')
+                 help='osg RELEASE version to use when updating packages '
+                 'specified with the -i flag.')
 
     p.add_option('-r', '--extra-repo', action='append', type='string',
-                      dest='extrarepos', metavar='REPO',
-                      help='Extra REPO (in addition to production) to use'
-                      ' when installing packages')
+                 dest='extrarepos', metavar='REPO',
+                 help='Extra REPO (in addition to production) to use'
+                 ' when installing packages')
 
     p.add_option('--no-print-test-name', action='store_false', dest='printtest',
-                       help='Do not print test name before command output')
+                 help='Do not print test name before command output')
 
     p.add_option('-T', '--skip', '--skip-tests', '--no-tests', '--notests',
-                      action='store_true', dest='skiptests',
-                      help='Do not run the functional tests; ' +
-                      'can enable install and cleanup separately')
+                 action='store_true', dest='skiptests',
+                 help='Do not run the functional tests; ' +
+                 'can enable install and cleanup separately')
 
     p.add_option('-u', '--test-user', action='store', type='string',
-                      dest='username', metavar='NAME',
-                      help='The NAME of an unprivileged user account that can '
-                      'be used to run (some) test commands (default: vdttest)')
+                 dest='username', metavar='NAME',
+                 help='The NAME of an unprivileged user account that can '
+                 'be used to run (some) test commands (default: vdttest)')
 
     p.add_option('-v', '--verbose', action='store_true', dest='verbose',
-                      help='Increase quantity of output')
+                 help='Increase quantity of output')
 
     p.add_option('--hostcert', action='store_true', dest='hostcert',
-                      help='Create host cert')
+                 help='Create host cert')
 
     return p
 
@@ -229,18 +228,18 @@ if __name__ == '__main__':
         sys.exit(1)
     get_password()
     core.start_log()
-    tests = discover_tests()
+    TESTS = discover_tests()
     try:
-        if len(tests) > 1:
+        if len(TESTS) > 1:
             signal.signal(signal.SIGALRM, signal_alarm_handler)
             signal.alarm(core.options.timeout)
             try:
-                run_tests(tests)
+                run_tests(TESTS)
             except KeyboardInterrupt:
-                tests = []
+                TESTS = []
                 if not core.options.skip_cleanup:
-                    tests.append('osgtest.tests.special_cleanup') # always safe
-                run_tests(tests)
+                    TESTS.append('osgtest.tests.special_cleanup') # always safe
+                run_tests(TESTS)
             signal.alarm(0)
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
         else:

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -69,6 +69,7 @@ def start_log():
     _log.write('  - No cleanup: %s\n' % str(options.skip_cleanup))
     _log.write('  - Extra repos: %s\n' % ', '.join(options.extrarepos))
     _log.write('  - Print test names: %s\n' % str(options.printtest))
+    _log.write('  - Enable SELinux: %s\n' % str(options.selinux))
     _log.write('  - Skip tests: %s\n' % str(options.skiptests))
     _log.write('  - Test user: %s\n' % options.username)
     _log.write('  - Timeout: %s\n' % str(options.timeout))

--- a/osgtest/tests/special_cleanup.py
+++ b/osgtest/tests/special_cleanup.py
@@ -138,6 +138,14 @@ class TestCleanup(osgunittest.OSGTestCase):
                 core.log_message('No new RPMs')
                 return
 
+    def test_04_selinux(self):
+        if not core.options.selinux:
+            return
+
+        self.skip_bad_unless(core.rpm_is_installed('libselinux-utils'), 'missing SELinux utils')
+        if core.state['selinux.mode'] == 'permissive':
+            core.check_system(('setenforce', '0'), 'set selinux mode to enforcing')
+
     def test_04_restore_orphaned_packages(self):
         # We didn't ask to install anything and thus didn't remove anything
         if len(core.options.packages) == 0:

--- a/osgtest/tests/special_cleanup.py
+++ b/osgtest/tests/special_cleanup.py
@@ -146,7 +146,7 @@ class TestCleanup(osgunittest.OSGTestCase):
         if core.state['selinux.mode'] == 'permissive':
             core.check_system(('setenforce', '0'), 'set selinux mode to enforcing')
 
-    def test_04_restore_orphaned_packages(self):
+    def test_05_restore_orphaned_packages(self):
         # We didn't ask to install anything and thus didn't remove anything
         if len(core.options.packages) == 0:
             return
@@ -162,12 +162,12 @@ class TestCleanup(osgunittest.OSGTestCase):
             if fail_msg:
                 self.fail(fail_msg)
 
-    def test_05_restore_mapfile(self):
+    def test_06_restore_mapfile(self):
         if core.state['system.wrote_mapfile']:
             files.restore(core.config['system.mapfile'], 'user')
 
 
-    def test_06_cleanup_test_certs(self):
+    def test_07_cleanup_test_certs(self):
         certs_dir = '/etc/grid-security/certificates'
         if core.state['certs.ca_created']:
             files.remove(os.path.join(certs_dir, 'OSG-Test-CA.*'))
@@ -196,7 +196,7 @@ class TestCleanup(osgunittest.OSGTestCase):
             files.remove(core.config['certs.hostcert'])
             files.remove(core.config['certs.hostkey'])
 
-    def test_07_remove_test_user(self):
+    def test_08_remove_test_user(self):
         if not core.state['general.user_added']:
             core.log_message('Did not add user')
             return
@@ -229,7 +229,7 @@ class TestCleanup(osgunittest.OSGTestCase):
 
     # The backups test should always be last, in case any prior tests restore
     # files from backup.
-    def test_08_backups(self):
+    def test_09_backups(self):
         record_is_clear = True
         if len(files._backups) > 0:
             details = ''

--- a/osgtest/tests/special_selinux.py
+++ b/osgtest/tests/special_selinux.py
@@ -1,0 +1,26 @@
+import re
+
+import osgtest.library.core as core
+import osgtest.library.osgunittest as osgunittest
+
+
+class TestSelinux(osgunittest.OSGTestCase):
+    def test_01_selinux(self):
+        if not core.options.selinux:
+            return
+
+        self.skip_bad_unless(core.rpm_is_installed('policycoreutils') and
+                             core.rpm_is_installed('libselinux-utils'),
+                             'missing SELinux utils')
+
+        stdout, _, _ = core.check_system(('sestatus',), 'acquire current selinux mode')
+        try:
+            core.state['selinux.mode'] = re.search(r'Current mode:\s*(\w*)', stdout, re.MULTILINE).group(1)
+            if core.state['selinux.mode'] == 'permissive':
+                core.check_system(('setenforce', '1'), 'set selinux mode to enforcing')
+        except AttributeError:
+            # If 'Current mode' doesn't appear, SELinux is probably in disabled mode
+            # and we cannot enable it via command-line utilities
+            core.state['selinux.mode'] = ''
+            self.fail("SELinux disabled: cannot enable SELinux from disabled mode")
+


### PR DESCRIPTION
https://jira.opensciencegrid.org/browse/SOFTWARE-2270

Pass `--selinux` to set SELinux to `enforcing` from `permissive` via `setenforce`. I spot checked the tests to verify that they're correctly enabling SELinux (or not in the first case): 

* VMU tests with SELinux disabled (default): http://vdt.cs.wisc.edu/tests/20160428-1329/results.html
   * 3.3 ALL tests are due to #7, which was merged after these tests were kicked off
   * Random errors appear unrelated
* VMU tests with SELinux enabled: http://vdt.cs.wisc.edu/tests/20160428-1335/results.html
   * 3.3 ALL tests are due to #7, which was merged after these tests were kicked off
   * EL6 CMVFS and cleanup test failures, presumably due to enabled SELinux
   * EL7 HTCondor-CE, RSV, and Globus-Condor job submission failures, presumably due to enabled SELinux

