### PR TITLE
Make osg-test RSV tests work with HTCondor-CE (SOFTWARE-2337)

### DIFF
--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -262,13 +262,15 @@ class TestRSV(osgunittest.OSGTestCase):
         return
 
     def test_051_osg_version_metric(self):
-        core.skip_ok_unless_installed('rsv', 'globus-gatekeeper')
+        core.skip_ok_unless_installed('rsv')
+        core.skip_ok_unless_one_installed('htcondor-ce', 'globus-gatekeeper')
 
         self.run_metric('org.osg.general.osg-version')
         return
 
     def test_052_vo_supported_metric(self):
-        core.skip_ok_unless_installed('rsv', 'globus-gatekeeper', 'gums-client')
+        core.skip_ok_unless_installed('rsv', 'gums-client')
+        core.skip_ok_unless_one_installed('htcondor-ce', 'globus-gatekeeper')
         # We ok skip if gums-client isn't installed since it's responsible
         # for creating /var/lib/osg/supported-vo-list in the tests.
         # edg-mkgridmap is also capable of creating the necessary file but
@@ -279,7 +281,8 @@ class TestRSV(osgunittest.OSGTestCase):
 
     # Print Java version info, mostly useful for debugging test runs.
     def test_053_java_version_metric(self):
-        core.skip_ok_unless_installed('rsv', 'globus-gatekeeper')
+        core.skip_ok_unless_installed('rsv')
+        core.skip_ok_unless_one_installed('htcondor-ce', 'globus-gatekeeper')
         self.run_metric('org.osg.general.java-version')
         return
 


### PR DESCRIPTION
Successful test run [here](http://vdt.cs.wisc.edu/tests/20160523-1321/results.html).  Without GUMS, we're now running the `osg-version` and `java-version` metrics. Once we get GUMS working, we'll also be testing the `vo-supported` metric.

New RSV EL7 skip list:

```
test_050_gram_authentication_metric (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_052_vo_supported_metric (osgtest.tests.test_47_rsv.TestRSV) missing gums-client
test_070_switch_to_user_proxy (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_071_gram_authentication_with_user_proxy (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_072_switch_to_service_cert (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_074_osg_version_with_globus_job_run (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
```

Compared to the old one:

```
test_050_gram_authentication_metric (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_051_osg_version_metric (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_052_vo_supported_metric (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper gums-client
test_053_java_version_metric (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_070_switch_to_user_proxy (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_071_gram_authentication_with_user_proxy (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_072_switch_to_service_cert (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
test_074_osg_version_with_globus_job_run (osgtest.tests.test_47_rsv.TestRSV) missing globus-gatekeeper
```