### PR TITLE
Limit the number of yum cleans that we perform in the tests (SOFTWARE…

### DIFF
--- a/osgtest/library/yum.py
+++ b/osgtest/library/yum.py
@@ -10,11 +10,6 @@ import time
 
 import osgtest.library.core as core
 
-def clean_yum():
-    pre = ('yum', '--enablerepo=*', 'clean')
-    core.system(pre + ('all',))
-    core.system(pre + ('expire-cache',))
-
 def retry_command(command, timeout_seconds=3600):
     """Run a Yum command repeatedly until success, hard failure, or timeout.
 
@@ -39,7 +34,6 @@ def retry_command(command, timeout_seconds=3600):
             fail_msg += "Retries terminated after timeout period"
             break
 
-        clean_yum()
         status, stdout, stderr = core.system(command)
 
         # Deal with success
@@ -49,6 +43,10 @@ def retry_command(command, timeout_seconds=3600):
         # Deal with failures that can be retried
         elif yum_failure_can_be_retried(stdout):
             time.sleep(30)
+            # Perform 'yum clean' commands that we recommend to our users
+            for subcmd in ('all', 'expire-cache'):
+                cmd = ('yum', '--enablerepo=*', 'clean', subcmd)
+                core.system(cmd)
             core.log_message("Retrying command")
             continue
 

--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -40,7 +40,7 @@ class TestInstall(osgunittest.OSGTestCase):
                 command.append('--enablerepo=%s' % repo)
             command += ['install', package]
 
-            retry_fail, status, stdout, stderr = yum.retry_command(command)
+            retry_fail, _, stdout, _ = yum.retry_command(command)
             if retry_fail == '':   # the command succeeded
                 if core.el_release() >= 6:
                     # RHEL 6 does not have the rollback option, so store the


### PR DESCRIPTION
…-2337)

Successful test results [here](http://vdt.cs.wisc.edu/tests/20160525-1011/results.html). Basically yum cleans are only performed on yum failures instead of at the beginning of each yum retried command.