### PR TITLE
Run osg-test with CILogon CA and certs

### DIFF
--- a/files/test_condorce_mapfile
+++ b/files/test_condorce_mapfile
@@ -1,6 +1,0 @@
-GSI "^\/DC\=com\/DC\=DigiCert-Grid\/O=Open Science Grid\/OU\=Services\/CN\=(host\/)?([A-Za-z0-9.\-]*)$" \2@daemon.opensciencegrid.org
-GSI "^\/DC\=org\/DC\=Open Science Grid\/O\=OSG Test\/OU\=Services\/CN\=(host\/)?([A-Za-z0-9.\-]*)$" \2@daemon.opensciencegrid.org
-GSI (.*) GSS_ASSIST_GRIDMAP
-GSI (.*) anonymous@gsi
-CLAIMTOBE .* anonymous@claimtobe
-FS (.*) \1

--- a/osg-test
+++ b/osg-test
@@ -21,6 +21,7 @@ from osgtest.library import osgunittest
 def parse_command_line():
     defaults = {"adduser": False,
                 "backupmysql": False,
+                "cilogon": False,
                 "config": None,
                 "dumpfile": None,
                 "dumpout": False,
@@ -92,6 +93,9 @@ def read_args():
 
     p.add_option('-a', '--add-user', action='store_true', dest='adduser',
                  help='Add and configure the test user account (see -u below)')
+
+    p.add_option('--cilogon', action='store_true', dest='cilogon',
+                 help='Generate CILogon-like certificates')
 
     p.add_option('-c', '--config', action='store', type='string', dest='config',
                  help='Configuration file to use that specifies command-line options')

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -60,6 +60,7 @@ def start_log():
     _log.write('Start time: ' + time.strftime('%Y-%m-%d %H:%M:%S') + '\n\n')
     _log.write('Options:\n')
     _log.write('  - Add user: %s\n' % str(options.adduser))
+    _log.write('  - CILogon-style certs: %s\n' % str(options.cilogon))
     _log.write('  - Config file: %s\n' % options.config)
     _log.write('  - Dump output: %s\n' % str(options.dumpout))
     _log.write('  - Dump file: %s\n' % options.dumpfile)

--- a/osgtest/tests/special_certs.py
+++ b/osgtest/tests/special_certs.py
@@ -9,7 +9,14 @@ class TestCert(osgunittest.OSGTestCase):
         core.state['certs.ca_created'] = False
         core.config['certs.test-ca'] = '/etc/grid-security/certificates/OSG-Test-CA.pem'
         self.skip_ok_if(os.path.exists(core.config['certs.test-ca']), 'OSG TEST CA already exists')
-        CA('/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA')
+        if core.options.cilogon:
+            subject_prefix = '/DC=org/DC=opensciencegrid/C=US/'
+            mimic_ca = 'cilogon'
+        else:
+            subject_prefix = '/DC=org/DC=Open Science Grid/'
+            mimic_ca = 'digicert'
+        core.config['certs.ca-subject'] = subject_prefix + 'O=OSG Software/CN=OSG Test CA'
+        CA(core.config['certs.ca-subject'], mimic=mimic_ca)
         core.state['certs.ca_created'] = True
 
     def test_02_install_host_cert(self):


### PR DESCRIPTION
[SOFTWARE-1863](https://jira.opensciencegrid.org/browse/SOFTWARE-1863)

With CILogon certs: http://vdt.cs.wisc.edu/tests/20160531-1654/results.html
With DigiCert certs: http://vdt.cs.wisc.edu/tests/20160531-1656/results.html

To run osg-test using CILogon-like certs, pass the `--cilogon` option or add `cilogon = True` to the osg-test config file.