### PR TITLE
Fix Gratia server.xml.template on EL7

### DIFF
--- a/osgtest/library/files.py
+++ b/osgtest/library/files.py
@@ -144,12 +144,9 @@ def replace(path, old_line, new_line, owner=None, backup=True):
     write(path, lines_to_write, owner, backup)
 
 def replace_regexpr(path, regexp, new_line, owner=None, backup=True):
-    """Replace an old line that matches regexpr with a new line in given path.                                                     
-    The 'owner' and 'backup' arguments are passed to write().                                                                                  
+    """Replace an old line that matches regexpr with a new line in given path.
+    The 'owner' and 'backup' arguments are passed to write().
     """
-    match = re.search(regexp, new_line)
-    if not match:
-       raise ValueError("The new_line '%s' does not match reg expr '%s'" % (new_line, regexp)) 
     lines_to_write = []
     lines = read(path)
     for line in lines:

--- a/osgtest/tests/test_23_gratia.py
+++ b/osgtest/tests/test_23_gratia.py
@@ -1,8 +1,10 @@
 import os
 import shutil
+
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.tomcat as tomcat
 
 class TestStartGratia(osgunittest.OSGTestCase):
 
@@ -163,4 +165,13 @@ class TestStartGratia(osgunittest.OSGTestCase):
             files.write(core.config['gratia.user-vo-map'],
                         conFileContents,
                         owner='root')
+
+    def test_10_fix_tomcat_template(self):
+        # Fix EL7 bug in Gratia template
+        if core.el_release() == 7:
+            core.skip_ok_unless_installed(tomcat.pkgname(), 'gratia-service')
+            core.config['gratia.broken_template'] = '/usr/share/gratia/server.xml.template'
+            bad_line = r'\s+sSLImplementation=.*'
+            fixed_line = ' '*15 + 'sslImplementationName="org.glite.security.trustmanager.tomcat.TMSSLImplementation"'
+            files.replace_regexpr(core.config['gratia.broken_template'], bad_line, fixed_line, owner='gratia')
 

--- a/osgtest/tests/test_80_gratia.py
+++ b/osgtest/tests/test_80_gratia.py
@@ -2,11 +2,12 @@ import os
 import shutil
 import time
 import datetime
+
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
-
+import osgtest.library.tomcat as tomcat
 
 class TestStopGratia(osgunittest.OSGTestCase):
 
@@ -181,3 +182,8 @@ class TestStopGratia(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('gratia-service')
         if files.filesBackedup(core.config['gratia.user-vo-map'], 'root'):
             files.restore(core.config['gratia.user-vo-map'], 'root')
+
+    def test_16_restore_tomcat_template(self):
+        if core.el_release() == 7:
+            core.skip_ok_unless_installed(tomcat.pkgname(), 'gratia-service')
+            files.restore(core.config['gratia.broken_template'], 'gratia')


### PR DESCRIPTION
#### Problem

GUMS + ALL EL7 tests were [broken](http://vdt.cs.wisc.edu/tests/20160603-1216/results.html) due to the incorrect `sSLImplementation` variable in the `server.xml.template` that Gratia uses in its tomcat configuration script: it needed to be `sslImplementationName`. Curiously, GUMS on EL5 and EL6 [broke](http://vdt.cs.wisc.edu/tests/20160606-1526/results.html) unless I used `sSLImplementation`. Sigh.

#### Solution

The successful run is [here](http://vdt.cs.wisc.edu/tests/20160607-1646/results.html) after fixing the above and a strange requirement of the `replace_regexpr()` function where the new line had to match the regex being replaced.

Do we also need to update osg-tested-internal on EL7 to now include GUMS?