### PR TITLE
Add DummyClass class that ignores everything

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -35,6 +35,13 @@ config['system.mapfile'] = '/etc/grid-security/grid-mapfile'
 # cutting objects.
 state = {}
 
+class DummyClass(object):
+    """A class that ignores all function calls; useful for testing"""
+    def __getattr__(self, item):
+        def handler(*args, **kwargs):
+            pass
+        return handler
+
 # Global command-line options.  This should be merged into the config object,
 # eventually.
 options = None
@@ -49,6 +56,14 @@ _el_release = None
 # ------------------------------------------------------------------------------
 # Global Functions
 # ------------------------------------------------------------------------------
+
+def init_dummy():
+    """Initialize 'options' and '_log' with dummy instances"""
+    global options, _log
+
+    options = DummyClass()
+    _log = DummyClass()
+
 
 def start_log():
     """Creates the detailed log file; not for general use."""


### PR DESCRIPTION
Also add `core.init_dummy()` which sets `core.options` and `core._log` to
instances of DummyClass (instead of None).  This lets me import and use
osg-test modules in the interpreter or in standalone scripts, without
getting AttributeErrors because the core functions were trying to do
`_log.write()` and access options.