### PR TITLE
get_package_envra: translate missing epochs to '0'

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -401,6 +401,9 @@ def get_package_envra(package_name):
     elif len(envra) != 5:
         raise OSError(status, stdout)
     (epoch, name, version, release, arch) = envra
+    # Missing epoch is displayed as '(none)' but treated by rpm as '0'
+    if epoch == '(none)':
+        epoch = '0'
     return (epoch, name, version, release, arch)
 
 


### PR DESCRIPTION
The query run by get_package_envra() returns a missing epoch as the
string '(none)', but an RPM with no epoch is considered the same (by
rpm.labelCompare()) as having the epoch '0'. Translate so the comparison
functions work properly.