### PR TITLE
edg-mkgridmap requires voms-admin, not voms

### DIFF
--- a/osgtest/tests/test_25_voms_admin.py
+++ b/osgtest/tests/test_25_voms_admin.py
@@ -4,9 +4,11 @@ import osgtest.library.osgunittest as osgunittest
 class TestSetupVomsAdmin(osgunittest.OSGTestCase):
 
     def test_01_open_access(self):
+        core.state['voms-admin.read-members'] = False
         core.skip_ok_unless_installed('voms-admin-server', 'voms-admin-client')
         self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         command = ('voms-admin', '--nousercert', '--vo', core.config['voms.vo'], 'add-ACL-entry',
                    '/' + core.config['voms.vo'], 'ANYONE', 'VOMS_CA', 'CONTAINER_READ,MEMBERSHIP_READ', 'true')
         core.check_system(command, 'Add VOMS Admin ACL entry')
+        core.state['voms-admin.read-members'] = True

--- a/osgtest/tests/test_51_edgmkgridmap.py
+++ b/osgtest/tests/test_51_edgmkgridmap.py
@@ -12,6 +12,7 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
         core.config['edg.conf'] = '/usr/share/osg-test/edg-mkgridmap.conf'
 
         core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
+        self.skip_bad_unless(core.state['voms-admin.read-members'], 'Cannot read VO member list')
         self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         contents = ('group vomss://%s:8443/voms/%s %s\n' %
@@ -21,6 +22,7 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
 
     def test_02_edg_mkgridmap(self):
         core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
+        self.skip_bad_unless(core.state['voms-admin.read-members'], 'Cannot read VO member list')
         self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         command = ('edg-mkgridmap', '--conf', core.config['edg.conf'])
@@ -44,6 +46,7 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
 
     def test_03_clean_edg_mkgridmap(self):
         core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
+        self.skip_bad_unless(core.state['voms-admin.read-members'], 'Cannot read VO member list')
         self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         for envvar in ('VO_LIST_FILE', 'UNDEFINED_ACCTS_FILE',

--- a/osgtest/tests/test_51_edgmkgridmap.py
+++ b/osgtest/tests/test_51_edgmkgridmap.py
@@ -11,7 +11,8 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
     def test_01_config_mkgridmap(self):
         core.config['edg.conf'] = '/usr/share/osg-test/edg-mkgridmap.conf'
 
-        core.skip_ok_unless_installed('edg-mkgridmap', 'voms-server')
+        core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
+        self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         contents = ('group vomss://%s:8443/voms/%s %s\n' %
                     (socket.getfqdn(), core.config['voms.vo'], core.options.username))
@@ -19,7 +20,8 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
         core.system(('cat', core.config['edg.conf']))
 
     def test_02_edg_mkgridmap(self):
-        core.skip_ok_unless_installed('edg-mkgridmap', 'voms-server')
+        core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
+        self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         command = ('edg-mkgridmap', '--conf', core.config['edg.conf'])
         os.environ['GRIDMAP'] = '/usr/share/osg-test/grid-mapfile'
@@ -41,7 +43,8 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
         self.assert_(expected in contents, 'Expected grid-mapfile contents')
 
     def test_03_clean_edg_mkgridmap(self):
-        core.skip_ok_unless_installed('edg-mkgridmap', 'voms-server')
+        core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
+        self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
 
         for envvar in ('VO_LIST_FILE', 'UNDEFINED_ACCTS_FILE',
                        'EDG_MKGRIDMAP_LOG', 'USER_VO_MAP', 'GRIDMAP'):


### PR DESCRIPTION
As you can see by the entry osg-test creates in `edg.conf`, `group vomss://HOSTNAME:8443/voms/...`, that's referencing a voms-admin service, not a voms service -- those run on 15151. Therefore, the tests should require a running voms-admin webapp, not a voms server.