### PR TITLE
Add voms library to set up a voms server without voms-admin

### DIFF
--- a/osgtest/library/voms.py
+++ b/osgtest/library/voms.py
@@ -27,7 +27,7 @@ def _get_sqlloc():
     return voms_mysql_so_path
 
 
-def create_vo(vo, dbusername, dbpassword, vomscert, vomskey, use_voms_admin=False):
+def create_vo(vo, dbusername='voms_osgtest', dbpassword='secret', vomscert='/etc/grid-security/voms/vomscert.pem', vomskey='/etc/grid-security/voms/vomskey.pem', use_voms_admin=False):
     """Create the given VO using either voms-admin or the voms_install_db script that comes with voms-server. A new
     database user with the given username/password is created with access to the VO database.
     """
@@ -66,7 +66,7 @@ def create_vo(vo, dbusername, dbpassword, vomscert, vomskey, use_voms_admin=Fals
         core.check_system(command, 'Create VO')
 
 
-def advertise_lsc(vo, hostcert):
+def advertise_lsc(vo, hostcert='/etc/grid-security/hostcert.pem'):
     """Create the VO directory and .lsc file under /etc/grid-security/vomsdir for the given VO"""
     host_dn, host_issuer = cagen.certificate_info(hostcert)
     hostname = socket.getfqdn()
@@ -77,7 +77,7 @@ def advertise_lsc(vo, hostcert):
     files.write(vo_lsc_path, (host_dn + '\n', host_issuer + '\n'), backup=False, chmod=0644)
 
 
-def advertise_vomses(vo, hostcert):
+def advertise_vomses(vo, hostcert='/etc/grid-security/hostcert.pem'):
     """Edit /etc/vomses to advertise the current host as the VOMS server for the given VO.
     Caller is responsible for preserving and restoring /etc/vomses.
     """

--- a/osgtest/library/voms.py
+++ b/osgtest/library/voms.py
@@ -1,0 +1,163 @@
+import os
+import shutil
+import socket
+
+import cagen
+from osgtest.library import core
+from osgtest.library import files
+from osgtest.library import mysql
+from osgtest.library import osgunittest
+
+
+
+def _get_sqlloc():
+    # Find full path to libvomsmysql.so
+    command = ('rpm', '--query', '--list', 'voms-mysql-plugin')
+    stdout = core.check_system(command, 'List VOMS-MySQL files')[0]
+    voms_mysql_files = stdout.strip().split('\n')
+    voms_mysql_so_path = None
+    for voms_mysql_path in voms_mysql_files:
+        if 'libvomsmysql.so' in voms_mysql_path:
+            voms_mysql_so_path = voms_mysql_path
+    assert voms_mysql_so_path is not None, \
+                'Could not find VOMS MySQL shared library path'
+    assert os.path.exists(voms_mysql_so_path), \
+                'VOMS MySQL shared library path does not exist'
+
+    return voms_mysql_so_path
+
+
+def create_vo(vo, dbusername, dbpassword, vomscert, vomskey, use_voms_admin=False):
+    """Create the given VO using either voms-admin or the voms_install_db script that comes with voms-server. A new
+    database user with the given username/password is created with access to the VO database.
+    """
+    if use_voms_admin:
+        command = ('voms-admin-configure', 'install',
+                   '--vo', vo,
+                   '--dbtype', 'mysql', '--createdb', '--deploy-database',
+                   '--dbauser', 'root', '--dbapwd', '', '--dbport', '3306',
+                   '--dbusername', dbusername, '--dbpassword', dbpassword,
+                   '--port', '15151', '--sqlloc', _get_sqlloc(),
+                   '--mail-from', 'root@localhost', '--smtp-host', 'localhost',
+                   '--cert', vomscert,
+                   '--key', vomskey,
+                   '--read-access-for-authenticated-clients')
+
+        stdout, _, fail = core.check_system(command, 'Configure VOMS Admin')
+        good_message = 'VO %s installation finished' % vo
+        assert good_message in stdout, fail
+
+    else:
+
+        mysql.execute("CREATE USER '%(dbusername)s'@'localhost';" % locals())
+
+        command = ['/usr/share/voms/voms_install_db',
+                   '--voms-vo=' + vo,
+                   '--port=15151',
+                   '--db-type=mysql',
+                   '--db-admin=root',
+                   '--voms-name=' + dbusername,
+                   '--voms-pwd=' + dbpassword,
+                   '--sqlloc=' + _get_sqlloc(),
+                   '--vomscert=' + vomscert,
+                   '--vomskey=' + vomskey,
+                   ]
+
+        core.check_system(command, 'Create VO')
+
+
+def advertise_lsc(vo, hostcert):
+    """Create the VO directory and .lsc file under /etc/grid-security/vomsdir for the given VO"""
+    host_dn, host_issuer = cagen.certificate_info(hostcert)
+    hostname = socket.getfqdn()
+    lsc_dir = os.path.join('/etc/grid-security/vomsdir', vo)
+    if not os.path.isdir(lsc_dir):
+        os.makedirs(lsc_dir)
+    vo_lsc_path = os.path.join(lsc_dir, hostname + '.lsc')
+    files.write(vo_lsc_path, (host_dn + '\n', host_issuer + '\n'), backup=False, chmod=0644)
+
+
+def advertise_vomses(vo, hostcert):
+    """Edit /etc/vomses to advertise the current host as the VOMS server for the given VO.
+    Caller is responsible for preserving and restoring /etc/vomses.
+    """
+    host_dn, _ = cagen.certificate_info(hostcert)
+    hostname = socket.getfqdn()
+    vomses_path = '/etc/vomses'
+    contents = ('"%s" "%s" "%d" "%s" "%s"\n' %
+                (vo, hostname, 15151, host_dn, vo))
+    files.write(vomses_path, contents, backup=False, chmod=0644)
+
+
+def add_user(vo, usercert, use_voms_admin=False):
+    """Add the user identified by the given cert to the specified VO. May use voms-admin or direct MySQL statements.
+    The CA cert that issued the user cert must already be in the database's 'ca' table - this happens automatically if
+    the CA cert is in /etc/grid-security/certificates when the VOMS database is created.
+    """
+    usercert_dn, usercert_issuer = cagen.certificate_info(usercert)
+    if use_voms_admin:
+        hostname = socket.getfqdn()
+
+        command = ('voms-admin', '--vo', core.config['voms.vo'], '--host', hostname, '--nousercert', 'create-user',
+               usercert_dn, usercert_issuer, 'OSG Test User', 'root@localhost')
+        core.check_system(command, 'Add VO user')
+
+    else:
+        dbname = 'voms_' + vo
+
+        # Find the index in the "ca" table ("cid") for the OSG Test CA that gets created by voms_install_db.
+        output, _, _, = mysql.check_execute(r'''SELECT cid FROM ca WHERE ca='%(usercert_issuer)s';''' % locals(),
+                                            'Get ID of user cert issuer from database', dbname)
+        output = output.strip()
+        assert output, "User cert issuer not found in database"
+        ca = int(output)
+
+        mysql.check_execute(r'''
+            INSERT INTO `usr` VALUES (1,'%(usercert_dn)s',%(ca)d,NULL,'root@localhost',NULL);
+            INSERT INTO `m` VALUES (1,1,1,NULL,NULL);''' % locals(),
+            'Add VO user', dbname)
+
+
+def destroy_lsc(vo):
+    """Remove the VO directory and .lsc file from under /etc/grid-security/vomsdir"""
+    lsc_dir = os.path.join('/etc/grid-security/vomsdir', vo)
+    if os.path.exists(lsc_dir):
+        shutil.rmtree(lsc_dir)
+
+
+def destroy_db(vo, dbusername=None):
+    """Destroy the VOMS database for the VO. If given, also remove the VO user from the database"""
+    dbname = 'voms_' + vo
+
+    mysql.execute('DROP DATABASE IF EXISTS `%s`;' % dbname)
+    if dbusername:
+        mysql.execute("DROP USER '%s'@'localhost';" % dbusername)
+
+
+def destroy_voms_conf(vo):
+    """Remove the VOMS config for the VO"""
+    vodir = os.path.join('/etc/voms', vo)
+    shutil.rmtree(vodir, ignore_errors=True)
+
+
+def is_installed():
+    """Return True if the dependencies for setting up and using VOMS are installed.
+    EL7 requires a minimum version of the voms-server package to get the service file fix from SOFTWARE-2357.
+    """
+    for dep in 'voms-server', 'voms-clients', 'voms-mysql-plugin', mysql.client_rpm(), mysql.server_rpm():
+        if not core.dependency_is_installed(dep):
+            return False
+
+    if core.el_release() >= 7:
+        epoch, _, version, release, _ = core.get_package_envra('voms-server')
+        if core.version_compare((epoch, version, release), '2.0.12-3.2') < 0:
+            core.log_message("voms-server installed but too old (missing SOFTWARE-2357 fix)")
+            return False
+
+    return True
+
+
+def skip_ok_unless_installed():
+    """OkSkip if the dependencies for setting up and using VOMS are not installed."""
+    if not is_installed():
+        raise osgunittest.OkSkipException('VOMS server requirements not installed')

--- a/osgtest/tests/test_20_voms.py
+++ b/osgtest/tests/test_20_voms.py
@@ -1,10 +1,10 @@
 import cagen
 import os
-import socket
 
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.tomcat as tomcat
+import osgtest.library.voms as voms
 import osgtest.library.osgunittest as osgunittest
 
 class TestStartVOMS(osgunittest.OSGTestCase):
@@ -16,7 +16,7 @@ class TestStartVOMS(osgunittest.OSGTestCase):
         core.config['certs.vomskey'] = '/etc/grid-security/voms/vomskey.pem'
 
     def test_02_install_voms_certs(self):
-        core.skip_ok_unless_installed('voms-server')
+        voms.skip_ok_unless_installed()
         vomscert = core.config['certs.vomscert']
         vomskey = core.config['certs.vomskey']
         self.skip_ok_if(core.check_file_and_perms(vomscert, 'voms', 0644) and
@@ -37,44 +37,26 @@ class TestStartVOMS(osgunittest.OSGTestCase):
 
     def test_04_config_voms(self):
         core.config['voms.vo'] = 'osgtestvo'
-        core.config['voms.lsc-dir'] = '/etc/grid-security/vomsdir/osgtestvo'
         core.config['voms.lock-file'] = '/var/lock/subsys/voms.osgtestvo'
         core.config['voms.vo-webapp'] = os.path.join(
             tomcat.datadir(), "conf/Catalina/localhost/voms#osgtestvo.xml")
         core.config['voms.webapp-log'] = os.path.join(
             tomcat.logdir(), 'voms-admin-osgtestvo.log')
+        # The DB created by voms-admin would have the user 'admin-osgtestvo',
+        # but the voms_install_db script provided by voms-server does not
+        # like usernames with '-' in them.
+        core.config['voms.dbusername'] = 'voms_' + core.config['voms.vo']
 
-    def test_05_configure_voms_admin(self):
-        core.skip_ok_unless_installed('voms-admin-server', 'voms-mysql-plugin')
+    def test_05_create_vo(self):
+        voms.skip_ok_unless_installed()
 
-        # Find full path to libvomsmysql.so
-        command = ('rpm', '--query', '--list', 'voms-mysql-plugin')
-        stdout = core.check_system(command, 'List VOMS-MySQL files')[0]
-        voms_mysql_files = stdout.strip().split('\n')
-        voms_mysql_so_path = None
-        for voms_mysql_path in voms_mysql_files:
-            if 'libvomsmysql.so' in voms_mysql_path:
-                voms_mysql_so_path = voms_mysql_path
-        self.assert_(voms_mysql_so_path is not None,
-                     'Could not find VOMS MySQL shared library path')
-        self.assert_(os.path.exists(voms_mysql_so_path),
-                     'VOMS MySQL shared library path does not exist')
-
-        # Configure VOMS Admin with new VO
-        db_user_name = 'admin-' + core.config['voms.vo']
-        command = ('voms-admin-configure', 'install',
-                   '--vo', core.config['voms.vo'],
-                   '--dbtype', 'mysql', '--createdb', '--deploy-database',
-                   '--dbauser', 'root', '--dbapwd', '', '--dbport', '3306',
-                   '--dbusername', db_user_name, '--dbpassword', 'secret',
-                   '--port', '15151', '--sqlloc', voms_mysql_so_path,
-                   '--mail-from', 'root@localhost', '--smtp-host', 'localhost',
-                   '--cert', core.config['certs.vomscert'],
-                   '--key', core.config['certs.vomskey'],
-                   '--read-access-for-authenticated-clients')
-        stdout, _, fail = core.check_system(command, 'Configure VOMS Admin')
-        good_message = 'VO %s installation finished' % (core.config['voms.vo'])
-        self.assert_(good_message in stdout, fail)
+        use_voms_admin = core.rpm_is_installed('voms-admin-server')
+        voms.create_vo(vo=core.config['voms.vo'],
+                       dbusername=core.config['voms.dbusername'],
+                       dbpassword='secret',
+                       vomscert=core.config['certs.vomscert'],
+                       vomskey=core.config['certs.vomskey'],
+                       use_voms_admin=use_voms_admin)
 
     def test_06_add_local_admin(self):
         core.skip_ok_unless_installed('voms-admin-server', 'voms-mysql-plugin')
@@ -105,19 +87,11 @@ class TestStartVOMS(osgunittest.OSGTestCase):
         files.write(path, contents, backup=False)
 
     def test_08_advertise(self):
-        core.skip_ok_unless_installed('voms-admin-server')
+        voms.skip_ok_unless_installed()
 
-        hostname = socket.getfqdn()
-        vomses_path = '/etc/vomses'
-        host_dn, host_issuer = cagen.certificate_info(core.config['certs.hostcert'])
-        contents = ('"%s" "%s" "%d" "%s" "%s"\n' %
-                    (core.config['voms.vo'], hostname, 15151, host_dn, core.config['voms.vo']))
-        files.write(vomses_path, contents, owner='voms', chmod=0644)
-
-        if not os.path.isdir(core.config['voms.lsc-dir']):
-            os.makedirs(core.config['voms.lsc-dir'])
-        vo_lsc_path = os.path.join(core.config['voms.lsc-dir'], hostname + '.lsc')
-        files.write(vo_lsc_path, (host_dn + '\n', host_issuer + '\n'), backup=False, chmod=0644)
+        voms.advertise_lsc(core.config['voms.vo'], core.config['certs.hostcert'])
+        files.preserve('/etc/vomses', owner='voms')
+        voms.advertise_vomses(core.config['voms.vo'], core.config['certs.hostcert'])
 
         core.system('ls -ldF /etc/*vom*', shell=True)
         core.system(('find', '/etc/grid-security/vomsdir', '-ls'))
@@ -125,14 +99,19 @@ class TestStartVOMS(osgunittest.OSGTestCase):
     def test_09_start_voms(self):
         core.state['voms.started-server'] = False
 
-        core.skip_ok_unless_installed('voms-server')
+        voms.skip_ok_unless_installed()
         self.skip_ok_if(os.path.exists(core.config['voms.lock-file']), 'apparently running')
 
-        command = ('service', 'voms', 'start')
-        stdout, _, fail = core.check_system(command, 'Start VOMS service')
-        self.assertEqual(stdout.find('FAILED'), -1, fail)
-        self.assert_(os.path.exists(core.config['voms.lock-file']),
-                     'VOMS server PID file is missing')
+        if core.el_release() < 7:
+            command = ('service', 'voms', 'start')
+            stdout, _, fail = core.check_system(command, 'Start VOMS service')
+            self.assertEqual(stdout.find('FAILED'), -1, fail)
+            self.assert_(os.path.exists(core.config['voms.lock-file']),
+                         'VOMS server PID file is missing')
+        else:
+            core.check_system(('systemctl', 'start', 'voms@' + core.config['voms.vo']), 'Start VOMS server')
+            core.check_system(('systemctl', 'is-active', 'voms@' + core.config['voms.vo']), 'Verify status of VOMS server')
+
         core.state['voms.started-server'] = True
 
     def test_10_install_vo_webapp(self):

--- a/osgtest/tests/test_78_voms.py
+++ b/osgtest/tests/test_78_voms.py
@@ -45,7 +45,8 @@ class TestStopVOMS(osgunittest.OSGTestCase):
             self.assert_('Database undeployed correctly!' in stdout, fail)
             self.assert_(' succesfully removed.' in stdout, fail)
 
-        # Really remove database
+        # Really remove database -- the voms-admin-configure command above does
+        # not actually destroy the mysql database.
         voms.destroy_db(core.config['voms.vo'], core.config['voms.dbusername'])
         voms.destroy_voms_conf(core.config['voms.vo'])
 

--- a/osgtest/tests/test_78_voms.py
+++ b/osgtest/tests/test_78_voms.py
@@ -1,54 +1,53 @@
-import glob
 import os
-import pwd
-import re
 import shutil
-import socket
-import time
-import unittest
 
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.voms as voms
+
 
 class TestStopVOMS(osgunittest.OSGTestCase):
 
     # ==========================================================================
 
     def test_01_stop_voms(self):
-        core.skip_ok_unless_installed('voms-server')
+        voms.skip_ok_unless_installed()
         self.skip_ok_unless(core.state['voms.started-server'], 'did not start server')
 
-        command = ('service', 'voms', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop VOMS server')
-        self.assertEqual(stdout.find('FAILED'), -1, fail)
-        self.assert_(not os.path.exists(core.config['voms.lock-file']),
-                     'VOMS server lock file still exists')
-
+        if core.el_release() < 7:
+            command = ('service', 'voms', 'stop')
+            stdout, _, fail = core.check_system(command, 'Stop VOMS server')
+            self.assertEqual(stdout.find('FAILED'), -1, fail)
+            self.assert_(not os.path.exists(core.config['voms.lock-file']),
+                         'VOMS server lock file still exists')
+        else:
+            core.check_system(('systemctl', 'stop', 'voms@' + core.config['voms.vo']), 'Stop VOMS server')
+            status, _, _ = core.system(('systemctl', 'is-active', 'voms@' + core.config['voms.vo']))
+            self.assertNotEqual(status, 0, 'VOMS server still active')
 
     def test_02_restore_vomses(self):
-        core.skip_ok_unless_installed('voms-admin-server')
+        voms.skip_ok_unless_installed()
 
-        if os.path.exists(core.config['voms.lsc-dir']):
-            shutil.rmtree(core.config['voms.lsc-dir'])
+        voms.destroy_lsc(core.config['voms.vo'])
         files.restore('/etc/vomses', 'voms')
 
 
     def test_03_remove_vo(self):
-        core.skip_ok_unless_installed('voms-admin-server', 'voms-mysql-plugin')
+        voms.skip_ok_unless_installed()
 
-        # Ask VOMS Admin to remove VO
-        command = ('voms-admin-configure', 'remove',
-                   '--vo', core.config['voms.vo'],
-                   '--undeploy-database')
-        stdout, _, fail = core.check_system(command, 'Remove VO')
-        self.assert_('Database undeployed correctly!' in stdout, fail)
-        self.assert_(' succesfully removed.' in stdout, fail)
+        if core.rpm_is_installed('voms-admin-server'):
+            # Ask VOMS Admin to remove VO
+            command = ('voms-admin-configure', 'remove',
+                       '--vo', core.config['voms.vo'],
+                       '--undeploy-database')
+            stdout, _, fail = core.check_system(command, 'Remove VO')
+            self.assert_('Database undeployed correctly!' in stdout, fail)
+            self.assert_(' succesfully removed.' in stdout, fail)
 
         # Really remove database
-        mysql_statement = "DROP DATABASE `voms_%s`" % (core.config['voms.vo'])
-        command = ('mysql', '-u', 'root', '-e', mysql_statement)
-        core.check_system(command, 'Drop MYSQL VOMS database')
+        voms.destroy_db(core.config['voms.vo'], core.config['voms.dbusername'])
+        voms.destroy_voms_conf(core.config['voms.vo'])
 
 
     def test_04_remove_certs(self):


### PR DESCRIPTION
This commit contains two major features:
- VOMS tests have been changed so that most of them will run without
  voms-admin.
- Code for using voms (setting up a vo, adding a user, tearing down the
  vo) has been moved to a separate library named `voms.py`, which can be
  imported and used standalone.

  By default, none of the functions require voms-admin, but two of them,
  `create_vo()` and `add_user()` have a `use_voms_admin` parameter which
  causes them to use the voms-admin-based code instead of the rewritten
  versions. The tests take advantage of this, using voms-admin if it is
  available.

Because many of the test functions have the same requirements (voms
client/server/mysql-plugin, mysql client/server, and, for EL 7, a
minimum version of voms-server), `voms.py` contains `is_installed()` and
`skip_ok_unless_installed()` to verify that the packages to run and use
a voms server are installed.

(SOFTWARE-2346)