### PR TITLE
Add tests for GSI-OpenSSH (SOFTWARE-2390)

### DIFF
--- a/files/test_sequence
+++ b/files/test_sequence
@@ -20,6 +20,7 @@ test_24_tomcat
 test_25_voms_admin
 test_26_bestman
 test_27_osg_info_services
+test_28_gsiopenssh
 test_30_misc
 test_35_osg_configure
 test_38_cvmfs
@@ -41,6 +42,7 @@ test_54_gratia
 test_55_condorce
 test_56_lcgutil
 test_57_osg_info_services
+test_59_gsiopenssh
 test_75_gums
 test_76_tomcat
 test_77_myproxy
@@ -58,6 +60,7 @@ test_88_condor_cron
 test_89_condor
 test_90_bestman
 test_91_pbs
+test_92_gsiopenssh
 test_95_mysqld
 test_96_proxy
 test_97_java

--- a/osgtest/tests/test_28_gsiopenssh.py
+++ b/osgtest/tests/test_28_gsiopenssh.py
@@ -1,0 +1,41 @@
+from osgtest.library import core
+from osgtest.library import osgunittest
+from osgtest.library import files
+from osgtest.library import service
+
+
+SSHD_CONFIG = "/etc/gsissh/sshd_config"
+SSHD_CONFIG_TEXT = r'''
+Port 2222
+AuthorizedKeysFile .ssh/authorized_keys
+UsePrivilegeSeparation sandbox
+
+GSSAPIAuthentication yes
+GSSAPIDelegateCredentials yes
+GSSAPICleanupCredentials yes
+GSSAPIStrictAcceptorCheck yes
+GSSAPIKeyExchange yes
+
+RSAAuthentication no
+PubkeyAuthentication no
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+
+Subsystem       sftp    /usr/libexec/gsissh/sftp-server
+'''
+
+
+class TestStartGSIOpenSSH(osgunittest.OSGTestCase):
+    def setUp(self):
+        core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
+
+    def test_01_set_config(self):
+        files.write(
+            SSHD_CONFIG,
+            SSHD_CONFIG_TEXT,
+            owner='gsissh',
+            chmod=0600)
+
+    def test_02_start(self):
+        core.state['gsisshd.started-service'] = False
+        service.start('gsisshd')

--- a/osgtest/tests/test_59_gsiopenssh.py
+++ b/osgtest/tests/test_59_gsiopenssh.py
@@ -1,0 +1,54 @@
+import os
+import pwd
+import shutil
+import socket
+import tempfile
+
+from osgtest.library import core
+from osgtest.library import osgunittest
+
+
+SOURCE_PATH = '/usr/share/osg-test/test_gridftp_data.txt'
+SSH_PORT = '2222'
+
+
+class TestGSIOpenSSH(osgunittest.OSGTestCase):
+    hostname = socket.getfqdn()
+    temp_dir = None
+    remote_path = None
+    local_path = None
+
+    def setUp(self):
+        core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
+        self.skip_ok_unless(core.state['proxy.created'] or core.state['voms.got-proxy'], 'no proxy')
+        self.skip_bad_unless(core.state['gsisshd.started-service'], 'gsisshd service not running')
+
+    def test_00_setup(self):
+        if not TestGSIOpenSSH.temp_dir or not os.path.isdir(TestGSIOpenSSH.temp_dir):
+            TestGSIOpenSSH.temp_dir = tempfile.mkdtemp()
+            uid, gid = pwd.getpwnam(core.options.username)[2:4]
+            os.chown(TestGSIOpenSSH.temp_dir, uid, gid)
+            TestGSIOpenSSH.remote_path = TestGSIOpenSSH.temp_dir + '/gsissh_put_copied_file.txt'
+            TestGSIOpenSSH.local_path = TestGSIOpenSSH.temp_dir + '/gsissh_get_copied_file.txt'
+
+    def test_01_ssh_to_host(self):
+        command = ['gsissh', '-p', SSH_PORT, self.hostname, 'echo', 'SUCCESS']
+        stdout, _, fail = core.check_system(command, 'SSH to host', user=True, stdin="")
+
+        self.assert_('SUCCESS' in stdout, fail)
+
+    def test_02_scp_local_to_remote(self):
+        command = ['gsiscp', '-P', SSH_PORT, SOURCE_PATH, self.hostname + ':' + self.remote_path]
+        stdout, _, fail = core.check_system(command, 'SCP to host', user=True, stdin="")
+
+        self.assert_(os.path.exists(self.remote_path), 'Copied file missing')
+
+    def test_03_scp_remote_to_local(self):
+        command = ['gsiscp', '-P', SSH_PORT, self.hostname + ':' + self.remote_path, self.local_path]
+        stdout, _, fail = core.check_system(command, 'SCP from host', user=True, stdin="")
+
+        self.assert_(os.path.exists(self.local_path), 'Copied file missing')
+
+    def test_99_cleanup(self):
+        shutil.rmtree(TestGSIOpenSSH.temp_dir)
+

--- a/osgtest/tests/test_92_gsiopenssh.py
+++ b/osgtest/tests/test_92_gsiopenssh.py
@@ -1,0 +1,18 @@
+from osgtest.library import core
+from osgtest.library import osgunittest
+from osgtest.library import files
+from osgtest.library import service
+
+
+SSHD_CONFIG = "/etc/gsissh/sshd_config"
+
+
+class TestStopGSIOpenSSH(osgunittest.OSGTestCase):
+    def setUp(self):
+        core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
+
+    def test_01_stop(self):
+        service.stop('gsisshd')
+
+    def test_02_restore_config(self):
+        files.restore(SSHD_CONFIG, owner='gsissh')


### PR DESCRIPTION
The tests are one run of gsissh to see if we can connect and run a
simple command, and two runs of gsiscp to see if we can copy files
to/from the remote server.  These tests require gsi-openssh-server,
gsi-openssh-clients, and a proxy.  The code for setting up the file
transfer tests was based off of the gfal2 test code.

A more global change: I changed special_user.py to give the vdttest user
a randomly-generated password.  SSH (including GSISSH) will consider a
user 'disabled' and refuse to log in as that user if the user does not
have a valid encrypted password in /etc/shadow.