### PR TITLE
script rename for gridftp-transfer probe (SOFTWARE-2398)

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -429,6 +429,20 @@ def version_compare(evr1, evr2):
 
     return rpm.labelCompare((epoch1, version1, release1), (epoch2, version2, release2))
 
+def package_version_compare(package_name, evr):
+    """Compare EVR of installed package_name to provided evr and return:
+      -1 if the package version is older than evr,
+       0 if the package version is equal to evr,
+       1 if the package version is newer than evr.
+
+    evr can be a string ("[E:]V[-R]") or 3-element tuple or list.
+
+    This is a wrapper around 'version_compare' that avoids having to call
+    'get_package_envra' and extract (e,v,r)
+    """
+    e,n,v,r,a = get_package_envra(package_name)
+    return version_compare((e,v,r), evr)
+
 
 def diagnose(message, command, status, stdout, stderr):
     """Constructs a detailed failure message based on arguments."""

--- a/osgtest/tests/test_54_gratia.py
+++ b/osgtest/tests/test_54_gratia.py
@@ -224,7 +224,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.state['gratia.gridftp-logs-copied'] = True
 
 
-    #This test executes the gridftp-transfer_meter
+    #This test executes the gridftp-transfer probe
     def test_06_execute_gridftptransfer_probedriver(self):
         core.state['gratia.gridftp-transfer-running'] = False
         core.skip_ok_unless_installed('gratia-probe-gridftp-transfer', 'gratia-service', 'globus-gridftp-server-progs',
@@ -235,8 +235,12 @@ class TestGratia(osgunittest.OSGTestCase):
             core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
-        command = ('/usr/share/gratia/gridftp-transfer/gridftp-transfer_meter',)
-        core.check_system(command, 'Unable to execute gridftp-transfer_meter.')
+        if core.package_version_compare('gratia-probe-gridftp-transfer', '1.17.0-1') >= 0:
+            probe_script = 'gridftp-transfer_meter'
+        else:
+            probe_script = 'GridftpTransferProbeDriver'
+        command = ('/usr/share/gratia/gridftp-transfer/%s' % probe_script,)
+        core.check_system(command, 'Unable to execute %s.' % probe_script)
         core.config['gratia.gridftp-temp-dir'] = core.config['gratia.tmpdir.prefix'] + "subdir.gridftp-transfer" + \
                                                  core.config['gratia.tmpdir.postfix']
         if core.state['gratia.database-installed'] == True:
@@ -244,7 +248,7 @@ class TestGratia(osgunittest.OSGTestCase):
             self.assert_(result, 'gridftp-transfer outbox check failed.')
         core.state['gratia.gridftp-transfer-running'] = True
 
-    #This test checks the database after the successful execution of gridftp-transfer_meter
+    #This test checks the database after the successful execution of the gridftp-transfer probe
     def test_07_checkdatabase_gridftptransfer_probedriver(self):
         core.skip_ok_unless_installed('gratia-probe-gridftp-transfer', 'gratia-service')
         self.skip_bad_if(core.state['gratia.gridftp-transfer-running'] == False, 'gridftp transfer probe not running')

--- a/osgtest/tests/test_54_gratia.py
+++ b/osgtest/tests/test_54_gratia.py
@@ -224,7 +224,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.state['gratia.gridftp-logs-copied'] = True
 
 
-    #This test executes the GridftpTransferProbeDriver
+    #This test executes the gridftp-transfer_meter
     def test_06_execute_gridftptransfer_probedriver(self):
         core.state['gratia.gridftp-transfer-running'] = False
         core.skip_ok_unless_installed('gratia-probe-gridftp-transfer', 'gratia-service', 'globus-gridftp-server-progs',
@@ -235,8 +235,8 @@ class TestGratia(osgunittest.OSGTestCase):
             core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
-        command = ('/usr/share/gratia/gridftp-transfer/GridftpTransferProbeDriver',)
-        core.check_system(command, 'Unable to execute GridftpTransferProbeDriver.')
+        command = ('/usr/share/gratia/gridftp-transfer/gridftp-transfer_meter',)
+        core.check_system(command, 'Unable to execute gridftp-transfer_meter.')
         core.config['gratia.gridftp-temp-dir'] = core.config['gratia.tmpdir.prefix'] + "subdir.gridftp-transfer" + \
                                                  core.config['gratia.tmpdir.postfix']
         if core.state['gratia.database-installed'] == True:
@@ -244,7 +244,7 @@ class TestGratia(osgunittest.OSGTestCase):
             self.assert_(result, 'gridftp-transfer outbox check failed.')
         core.state['gratia.gridftp-transfer-running'] = True
 
-    #This test checks the database after the successful execution of GridftpTransferProbeDriver
+    #This test checks the database after the successful execution of gridftp-transfer_meter
     def test_07_checkdatabase_gridftptransfer_probedriver(self):
         core.skip_ok_unless_installed('gratia-probe-gridftp-transfer', 'gratia-service')
         self.skip_bad_if(core.state['gratia.gridftp-transfer-running'] == False, 'gridftp transfer probe not running')


### PR DESCRIPTION
The GridftpTransferProbeDriver script (along with other items from the
gridftp-transfer probe) was replaced gridftp-transfer_meter.

It's not obvious if other changes need to be made also to the tests, but
this much at least clearly will need to be changed...