### PR TITLE
Various fixes to HTCondor-CE tests

### DIFF
--- a/osgtest/library/condor.py
+++ b/osgtest/library/condor.py
@@ -37,8 +37,8 @@ def is_running():
 def wait_for_daemon(collector_log_path, stat, daemon, timeout):
     """Wait until the requested 'daemon' is available and accepting commands by
     monitoring the specified CollectorLog from the position specified by 'stat'
-    for a maximum of 'timeout' seconds (default: 60). Returns True if the daemon
-    becomes available within the timeout period and False, otherwise.
+    for a maximum of 'timeout' seconds. Returns True if the daemon becomes 
+    available within the timeout period and False, otherwise.
 
     """
     sentinel = r'%sAd\s+:\s+Inserting' % daemon.capitalize()

--- a/osgtest/library/condor.py
+++ b/osgtest/library/condor.py
@@ -34,3 +34,13 @@ def is_running():
         returncode, _, _ = core.system(['service', 'condor', 'status'])
         return returncode == 0
 
+def wait_for_daemon(collector_log_path, stat, daemon, timeout):
+    """Wait until the requested 'daemon' is available and accepting commands by
+    monitoring the specified CollectorLog from the position specified by 'stat'
+    for a maximum of 'timeout' seconds (default: 60). Returns True if the daemon
+    becomes available within the timeout period and False, otherwise.
+
+    """
+    sentinel = r'%sAd\s+:\s+Inserting' % daemon.capitalize()
+    return bool(core.monitor_file(collector_log_path, stat, sentinel, timeout)[0])
+

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -560,6 +560,20 @@ def __run_command(command, use_test_user, a_input, a_stdout, a_stderr, log_outpu
 
     return (p.returncode, stdout, stderr)
 
+def wait_for_file(filename, timeout):
+    """Wait maximum 'timeout' seconds for filename to be created. Returns True
+    if created within the timeout, False otherwise.
+
+    """
+    elapsed_time = 0
+    while elapsed_time <= timeout:
+        if os.path.exists(filename):
+            return True
+        else:
+            time.sleep(1)
+            elapsed_time += 1
+
+    return False
 
 def el_release():
     """Return the major version of the Enterprise Linux release the system is

--- a/osgtest/tests/test_10_condor.py
+++ b/osgtest/tests/test_10_condor.py
@@ -11,6 +11,9 @@ class TestStartCondor(osgunittest.OSGTestCase):
         core.state['condor.running-service'] = False
 
         core.skip_ok_unless_installed('condor')
+        core.config['condor.collectorlog'] = core.check_system(('condor_config_val', 'COLLECTOR_LOG'),
+                                                               'Failed to query for Condor CollectorLog path')[0]\
+                                                 .strip()
 
         if condor.is_running():
             core.state['condor.running-service'] = True
@@ -22,3 +25,7 @@ class TestStartCondor(osgunittest.OSGTestCase):
         self.assert_(condor.is_running(), 'Condor not running after we started it')
         core.state['condor.running-service'] = True
 
+        try:
+            core.config['condor.collectorlog_stat'] = os.stat(core.config['condor.collectorlog'])
+        except OSError:
+            core.config['condor.collectorlog_stat'] = None

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -100,6 +100,7 @@ gridmapfile -> good | bad
         command = ('service', 'condor-ce', 'start')
         stdout, _, fail = core.check_system(command, 'Start HTCondor CE')
         self.assert_(stdout.find('FAILED') == -1, fail)
+        core.wait_for_file(core.config['condor-ce.lockfile'], 60.0)
         self.assert_(os.path.exists(core.config['condor-ce.lockfile']),
                      'HTCondor CE run lock file missing')
         core.state['condor-ce.started'] = True

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -13,7 +13,7 @@ class TestStartCondorCE(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
 
         core.config['condor-ce.condor-cfg'] = '/etc/condor/config.d/99-osgtest.condor.conf'
-        contents = """SCHEDD_INTERVAL=5"""
+        contents = """SCHEDD_INTERVAL=1"""
 
         files.write(core.config['condor-ce.condor-cfg'],
                     contents,

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -24,10 +24,16 @@ class TestStartCondorCE(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
         self.skip_bad_unless(core.state['condor.running-service'], 'Condor not running')
 
+        # Ensure that the Condor master is available for reconfig
+        self.failUnless(condor.wait_for_daemon(core.config['condor.collectorlog'],
+                                               core.config['condor.collectorlog_stat'],
+                                               'Master',
+                                               300.0),
+                        'Condor Master not available for reconfig')
+
         command = ('condor_reconfig', '-debug')
         core.check_system(command, 'Reconfigure Condor')
-        self.assert_(condor.is_running(),
-                     'Condor not running after reconfig')
+        self.assert_(condor.is_running(), 'Condor not running after reconfig')
 
     def test_03_configure_authentication(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
@@ -80,9 +86,13 @@ gridmapfile -> good | bad
     def test_05_start_condorce(self):
         core.config['condor-ce.lockfile'] = '/var/lock/subsys/condor-ce'
         core.state['condor-ce.started'] = False
+        core.state['condor-ce.schedd-ready'] = False
 
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
         self.skip_ok_if(os.path.exists(core.config['condor-ce.lockfile']), 'already running')
+        core.config['condor-ce.collectorlog'] = core.check_system(('condor_ce_config_val', 'COLLECTOR_LOG'),
+                                                                  'Failed to query for Condor CE CollectorLog path')[0]\
+                                                    .strip()
 
         command = ('service', 'condor-ce', 'start')
         stdout, _, fail = core.check_system(command, 'Start HTCondor CE')
@@ -90,3 +100,10 @@ gridmapfile -> good | bad
         self.assert_(os.path.exists(core.config['condor-ce.lockfile']),
                      'HTCondor CE run lock file missing')
         core.state['condor-ce.started'] = True
+
+        try:
+            stat = os.stat(core.config['condor-ce.collectorlog'])
+        except OSError:
+            stat = None
+        if condor.wait_for_daemon(core.config['condor-ce.collectorlog'], stat, 'Schedd', 300.0):
+            core.state['condor-ce.schedd-ready'] = True

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -84,7 +84,10 @@ gridmapfile -> good | bad
                         chmod=0644)
 
     def test_05_start_condorce(self):
-        core.config['condor-ce.lockfile'] = '/var/lock/subsys/condor-ce'
+        if core.el_release() >= 7:
+            core.config['condor-ce.lockfile'] = '/var/lock/condor-ce/htcondor-ceLock'
+        else:
+            core.config['condor-ce.lockfile'] = '/var/lock/subsys/condor-ce'
         core.state['condor-ce.started'] = False
         core.state['condor-ce.schedd-ready'] = False
 

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -99,7 +99,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
     def test_05_condor_ce_run_condor(self):
         core.skip_ok_unless_installed('htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor', 'condor')
 
-        self.skip_bad_unless('condor-ce.started', 'ce not started')
+        self.skip_bad_unless(core.state['condor-ce.started'], 'ce not started')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
 
         command = ('condor_ce_run', '-r', '%s:9619' % core.get_hostname(), '/bin/env')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -15,7 +15,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
     def test_01_status(self):
         self.general_requirements()
 
-        command = ('condor_ce_status', '-long')
+        command = ('condor_ce_status', '-any')
         core.check_system(command, 'ce status', user=True)
 
     def test_02_queue(self):

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -3,6 +3,8 @@
 
 import os
 import re
+
+import osgtest.library.condor as condor
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
@@ -33,6 +35,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
 
     def test_04_trace(self):
         self.general_requirements()
+        self.skip_bad_unless(core.state['condor-ce.schedd-ready'], 'CE schedd not ready to accept jobs')
 
         cwd = os.getcwd()
         os.chdir('/tmp')
@@ -44,6 +47,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
 
     def test_05_pbs_trace(self):
         self.general_requirements()
+        self.skip_bad_unless(core.state['condor-ce.schedd-ready'], 'CE schedd not ready to accept jobs')
         core.skip_ok_unless_installed('torque-mom', 'torque-server', 'torque-scheduler', 'torque-client', 'munge')
         self.skip_ok_unless(core.state['torque.pbs-server-running'])
 
@@ -58,6 +62,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
     def test_06_use_gums_auth(self):
         self.general_requirements()
         core.skip_ok_unless_installed('gums-service')
+        core.state['condor-ce.gums-auth'] = False
 
         # Setting up GUMS auth using the instructions here:
         # twiki.grid.iu.edu/bin/view/Documentation/Release3/InstallComputeElement#8_1_Using_GUMS_for_Authorization
@@ -104,24 +109,22 @@ gums.authz=https://%s:8443/gums/services/GUMSXACMLAuthorizationServicePort
         command = ('service', 'condor-ce', 'stop')
         core.check_system(command, 'stop condor-ce')
 
-        # Need to stat the Schedd logfile so we know when it's back up
-        core.config['condor-ce.schedlog'] = '/var/log/condor-ce/SchedLog'
-        core.config['condor-ce.schedlog-stat'] = os.stat(core.config['condor-ce.schedlog'])
-
         command = ('service', 'condor-ce', 'start')
         core.check_system(command, 'start condor-ce')
+        core.state['condor-ce.gums-auth'] = True
 
     def test_07_ping_with_gums(self):
         self.general_requirements()
         core.skip_ok_unless_installed('gums-service')
+        self.skip_bad_unless(core.state['condor-ce.gums-auth'], 'CE not using GUMS auth')
 
-        # Wait for the collector to come back up
-        core.monitor_file(core.config['condor-ce.schedlog'],
-                          core.config['condor-ce.schedlog-stat'],
-                          'TransferQueueManager stats',
-                          60.0)
-
+        # Wait for the schedd to come back up
+        try:
+            stat = os.stat(core.config['condor-ce.collectorlog'])
+        except OSError:
+            stat = None
+        self.failUnless(condor.wait_for_daemon(core.config['condor-ce.collectorlog'], stat, 'Schedd', 300.0),
+                        'Schedd failed to restart within the 1 min window')
         command = ('condor_ce_ping', 'WRITE', '-verbose')
         stdout, _, _ = core.check_system(command, 'ping using GSI and gridmap', user=True)
         self.assert_(re.search(r'Authorized:\s*TRUE', stdout), 'could not authorize with GSI')
-


### PR DESCRIPTION
Commit messages should be descriptive enough for the small changes. Bigger changes are the added functions that:

* Wait for requested condor daemon availability
* Wait for a file to be created, which is useful for systemd lockfile generation

These changes were made to accommodate [SOFTWARE-2419](https://jira.opensciencegrid.org/browse/SOFTWARE-2419) and to eliminate the 'random' errors that would occur in HTCondor-CE's Travis-CI tests.

Test results:

[Test failures look to be random or due to the changed gridftp probe name](http://vdt.cs.wisc.edu/tests/20160826-1225/results.html)
[SL6 HTCondor-CE Travis-CI](https://travis-ci.org/brianhlin/htcondor-ce/jobs/155940747)
[SL7 HTCondor-CE Travis-CI](https://travis-ci.org/brianhlin/htcondor-ce/jobs/155940748)
