### PR TITLE
We don't need osg-configure to run jobs, just the env files

### DIFF
--- a/osgtest/tests/test_09_jobs.py
+++ b/osgtest/tests/test_09_jobs.py
@@ -2,6 +2,8 @@
 #pylint: disable=C0111
 #pylint: disable=R0201
 #pylint: disable=R0904
+import os
+import errno
 
 import osgtest.library.core as core
 import osgtest.library.files as files
@@ -13,11 +15,16 @@ class TestConfigureJobs(osgunittest.OSGTestCase):
     def test_01_set_job_env(self):
         # Jobs get submitted with globus-job-run, condor_run, and condor_ce_run
         core.state['jobs.env-set'] = False
-        core.skip_ok_unless_installed('osg-configure')
         core.skip_ok_unless_one_installed(['htcondor-ce', 'globus-gatekeeper', 'condor'])
 
-        core.config['osg.job-environment'] = '/var/lib/osg/osg-job-environment.conf'
-        core.config['osg.local-job-environment'] = '/var/lib/osg/osg-local-job-environment.conf'
+        osg_libdir = os.path.join('/var', 'lib', 'osg')
+        try:
+            os.makedirs(osg_libdir)
+        except OSError, exc:
+            if exc.errno != errno.EEXIST:
+                raise
+        core.config['osg.job-environment'] = os.path.join(osg_libdir, 'osg-job-environment.conf')
+        core.config['osg.local-job-environment'] = os.path.join(osg_libdir, 'osg-local-job-environment.conf')
 
         files.write(core.config['osg.job-environment'],
                     "#!/bin/sh\nJOB_ENV='vdt'\nexport JOB_ENV",


### PR DESCRIPTION
Just something I noticed when working on the CE tests. Test results look good [here](http://vdt.cs.wisc.edu/tests/20160830-1136/results.html) and I did some spot checks to make sure that the job submission tests ran as expected.

