### PR TITLE
Improve tomcat7 startup time in VMU tests for non-nightly runs (SOFTWARE-2383)

### DIFF
--- a/osg-test
+++ b/osg-test
@@ -28,6 +28,8 @@ def parse_command_line():
                 "extrarepos": [],
                 "exitonfail": False,
                 "hostcert": False,
+                # Allow VMU nightly tests to have longer test timeouts
+                "nightly": False,
                 "packages": [],
                 "password": 'vdttest',
                 "printtest": True,

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -94,6 +94,7 @@ def start_log():
     _log.write('  - Timeout: %s\n' % str(options.timeout))
     _log.write('  - Create hostcert: %s\n' % str(options.hostcert))
     _log.write('  - Backup MySQL: %s\n' % str(options.backupmysql))
+    _log.write('  - Nightly: %s\n' % str(options.nightly))
     _log.flush()
 
 

--- a/osgtest/library/tomcat.py
+++ b/osgtest/library/tomcat.py
@@ -34,6 +34,10 @@ def conffile():
     "Path of main config file of Tomcat"
     return os.path.join(sysconfdir(), pkgname() + ".conf")
 
+def contextfile():
+    "Path of main context.xml file of Tomcat"
+    return os.path.join(sysconfdir(), 'context.xml')
+
 def catalinafile():
     "Path of Catalina log file that contains the startup sentinel"
     if majorver() <= 6:

--- a/osgtest/tests/test_24_tomcat.py
+++ b/osgtest/tests/test_24_tomcat.py
@@ -41,6 +41,18 @@ class TestStartTomcat(osgunittest.OSGTestCase):
         new_contents = '\n'.join([old_contents] + lines)
         files.write(tomcat.conffile(), new_contents, owner='tomcat')
 
+    def test_04_disable_persistence(self):
+        core.skip_ok_unless_installed(tomcat.pkgname())
+        if core.el_release() > 5: # Disabling persistence doesn't appear to work on EL5
+            # https://tomcat.apache.org/tomcat-5.5-doc/config/manager.html#Disable_Session_Persistence
+            contents='''
+<Context>
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <Manager pathname="" />
+</Context>
+'''
+            files.write(tomcat.contextfile(), contents, owner='tomcat')
+
     def test_04_configure_gratia(self):
         core.skip_ok_unless_installed(tomcat.pkgname(), 'gratia-service')
         command = ('/usr/share/gratia/configure_tomcat',)
@@ -58,14 +70,18 @@ class TestStartTomcat(osgunittest.OSGTestCase):
 
         if tomcat.majorver() > 5:
             tomcat_sentinel = r'Server startup in \d+ ms'
-        else:
             # tomcat5 doesn't have an explicit sentinel for server startup
             # so we use a heartbeat-like message that shows up in catalin.out
             # with an increased log level
-            core.config['tomcat.logging-conf'] = os.path.join(tomcat.sysconfdir(), 'logging.properties')
-            files.append(core.config['tomcat.logging-conf'], 'org.apache.catalina.level = FINEST\n',
-                         owner='tomcat', backup=True)
+            log_level = 'FINER'
+        else:
             tomcat_sentinel = r'Start expire sessions'
+            log_level = 'FINEST'
+
+        # Bump log level
+        core.config['tomcat.logging-conf'] = os.path.join(tomcat.sysconfdir(), 'logging.properties')
+        files.append(core.config['tomcat.logging-conf'], 'org.apache.catalina.level = %s\n' % log_level,
+                     owner='tomcat', backup=True)
 
         if core.el_release() == 7:
             # tomcat on el7 doesn't seem to actually use its always-present pidfile...

--- a/osgtest/tests/test_76_tomcat.py
+++ b/osgtest/tests/test_76_tomcat.py
@@ -29,13 +29,14 @@ class TestStopTomcat(osgunittest.OSGTestCase):
 
     def test_04_deconfig_catalina_logging(self):
         core.skip_ok_unless_installed(tomcat.pkgname())
+        files.restore(core.config['tomcat.logging-conf'], 'tomcat')
 
-        # We don't use self.skip_ok_unless() here to avoid
-        # filling the okskip list with uninteresting results
-        if core.el_release() == 5:
-            files.restore(core.config['tomcat.logging-conf'], 'tomcat')
+    def test_05_deconfig_context(self):
+        core.skip_ok_unless_installed(tomcat.pkgname())
+        if core.el_release() > 5:
+            files.restore(tomcat.contextfile(), 'tomcat')
 
-    def test_04_remove_trustmanager(self):
+    def test_06_remove_trustmanager(self):
         core.skip_ok_unless_installed(tomcat.pkgname(), 'emi-trustmanager-tomcat')
 
         # mv -f /etc/tomcat5/server.xml.old-trustmanager /etc/tomcat5/server.xml
@@ -61,7 +62,7 @@ class TestStopTomcat(osgunittest.OSGTestCase):
 
         core.log_message('EMI trustmanager removed')
     
-    def test_05_deconfig_tomcat(self):
+    def test_07_deconfig_tomcat(self):
         core.skip_ok_unless_installed(tomcat.pkgname())
 
         files.restore(tomcat.conffile(), 'tomcat')

--- a/osgtest/tests/test_76_tomcat.py
+++ b/osgtest/tests/test_76_tomcat.py
@@ -33,6 +33,7 @@ class TestStopTomcat(osgunittest.OSGTestCase):
 
     def test_05_deconfig_context(self):
         core.skip_ok_unless_installed(tomcat.pkgname())
+        self.skip_ok_if(core.options.nightly, 'Allow persistence in the nightlies')
         if core.el_release() > 5:
             files.restore(tomcat.contextfile(), 'tomcat')
 


### PR DESCRIPTION
[SOFTWARE-2383](https://jira.opensciencegrid.org/browse/SOFTWARE-2383)

### Test results ###

* [With nightly=False (the default)](http://vdt.cs.wisc.edu/tests/20160906-1532/results.html) with the following failures:
  * MyProxy tests failing with 3.3 testing because I didn't grab d1177fc from master
  * Handful of random RHEL7 install and VM startup failures
* [With nightly=True](http://vdt.cs.wisc.edu/tests/20160906-1533/results.html) with the following failures:
  * Same MyProxy and RHEL7 install failures as above
  * Random Bestman/Gfal2 (1x) and EL5 SSL yum failures (4x)

### Summary ###

Added a nightly option that will give us the flexibility to speed up tests in the future for any manual VMU runs so that developers won't have to wait as long for their results. Specifically in this change, we are disabling Tomcat persistence for EL6+ tests since we don't have to bother surviving restarts of the service.

By default, osg-test uses these sped up tests and the nightly test infrastructure will specify that it has a higher tolerance for lengthy test runs.

