### PR TITLE
Ensure that PBS jobs cannot match to the condor backend

### DIFF
--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -52,6 +52,7 @@ JOB_ROUTER_ENTRIES = \\
    [ \\
      TargetUniverse = 5; \\
      name = "Local_Condor"; \\
+     Requirements = target.osgTestPBS =!= true; \\
    ]
 
 JOB_ROUTER_SCHEDD2_SPOOL=/var/lib/condor/spool


### PR DESCRIPTION
Noticed when testing [BLAHP #47](https://github.com/osg-bosco/BLAH/pull/47)