### PR TITLE
Fix condor-cron start/stop to work with systemd

### DIFF
--- a/osgtest/library/service.py
+++ b/osgtest/library/service.py
@@ -115,3 +115,4 @@ def is_running(service_name, init_script=None):
     status, _, _ = core.system(command, 'Checking status of ' + service_name + ' service')
 
     return status == 0
+

--- a/osgtest/library/service.py
+++ b/osgtest/library/service.py
@@ -107,10 +107,11 @@ def is_running(service_name, init_script=None):
     """
     init_script = _init_script_name(service_name, init_script)
 
-    command = ('service', init_script, 'status')
+    if core.el_release() >= 7:
+        command = ('systemctl', 'is-active', init_script)
+    else:
+        command = ('service', init_script, 'status')
+
     status, _, _ = core.system(command, 'Checking status of ' + service_name + ' service')
 
-    if status == 0:
-        return True
-
-    return False
+    return status == 0

--- a/osgtest/tests/test_11_condor_cron.py
+++ b/osgtest/tests/test_11_condor_cron.py
@@ -15,10 +15,15 @@ class TestStartCondorCron(osgunittest.OSGTestCase):
             core.state['condor-cron.running-service'] = True
             self.skip_ok('already running')
 
-        command = ('service', 'condor-cron', 'start')
-        stdout, _, fail = core.check_system(command, 'Start Condor-Cron')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(os.path.exists(core.config['condor-cron.lockfile']),
-                     'Condor-Cron run lock file missing')
+        if core.el_release() < 7:
+            command = ('service', 'condor-cron', 'start')
+            stdout, _, fail = core.check_system(command, 'Start Condor-Cron')
+            self.assert_(stdout.find('error') == -1, fail)
+            self.assert_(os.path.exists(core.config['condor-cron.lockfile']),
+                         'Condor-Cron run lock file missing')
+        else:
+            core.check_system(('systemctl', 'start', 'condor-cron'), 'Start Condor-Cron')
+            core.check_system(('systemctl', 'is-active', 'condor-cron'), 'Verify status of Condor-Cron')
+
         core.state['condor-cron.started-service'] = True
         core.state['condor-cron.running-service'] = True

--- a/osgtest/tests/test_11_condor_cron.py
+++ b/osgtest/tests/test_11_condor_cron.py
@@ -4,14 +4,23 @@ import osgtest.library.osgunittest as osgunittest
 import unittest
 
 class TestStartCondorCron(osgunittest.OSGTestCase):
+    def is_running(self):
+        # TODO Move this to library/service.py
+        if core.el_release() < 7:
+            command = ['service', 'condor-cron', 'status']
+        else:
+            command = ['systemctl', 'is-active', 'condor-cron']
+
+        status, _, _ = core.system(command)
+
+        return status == 0
 
     def test_01_start_condor_cron(self):
-        core.config['condor-cron.lockfile'] = '/var/lock/subsys/condor-cron'
         core.state['condor-cron.started-service'] = False
         core.state['condor-cron.running-service'] = False
 
         core.skip_ok_unless_installed('condor-cron')
-        if os.path.exists(core.config['condor-cron.lockfile']):
+        if self.is_running():
             core.state['condor-cron.running-service'] = True
             self.skip_ok('already running')
 
@@ -19,11 +28,10 @@ class TestStartCondorCron(osgunittest.OSGTestCase):
             command = ('service', 'condor-cron', 'start')
             stdout, _, fail = core.check_system(command, 'Start Condor-Cron')
             self.assert_(stdout.find('error') == -1, fail)
-            self.assert_(os.path.exists(core.config['condor-cron.lockfile']),
-                         'Condor-Cron run lock file missing')
         else:
             core.check_system(('systemctl', 'start', 'condor-cron'), 'Start Condor-Cron')
-            core.check_system(('systemctl', 'is-active', 'condor-cron'), 'Verify status of Condor-Cron')
+
+        self.assert_(self.is_running(), "Condor-Cron is not running")
 
         core.state['condor-cron.started-service'] = True
         core.state['condor-cron.running-service'] = True

--- a/osgtest/tests/test_11_condor_cron.py
+++ b/osgtest/tests/test_11_condor_cron.py
@@ -2,6 +2,7 @@ import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
+import time
 import unittest
 
 class TestStartCondorCron(osgunittest.OSGTestCase):
@@ -20,6 +21,9 @@ class TestStartCondorCron(osgunittest.OSGTestCase):
             self.assert_(stdout.find('error') == -1, fail)
         else:
             core.check_system(('systemctl', 'start', 'condor-cron'), 'Start Condor-Cron')
+
+        # Give condor-cron time to start up
+        time.sleep(5)
 
         self.assert_(service.is_running('condor-cron'), "Condor-Cron is not running")
 

--- a/osgtest/tests/test_11_condor_cron.py
+++ b/osgtest/tests/test_11_condor_cron.py
@@ -1,26 +1,16 @@
 import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
 import unittest
 
 class TestStartCondorCron(osgunittest.OSGTestCase):
-    def is_running(self):
-        # TODO Move this to library/service.py
-        if core.el_release() < 7:
-            command = ['service', 'condor-cron', 'status']
-        else:
-            command = ['systemctl', 'is-active', 'condor-cron']
-
-        status, _, _ = core.system(command)
-
-        return status == 0
-
     def test_01_start_condor_cron(self):
         core.state['condor-cron.started-service'] = False
         core.state['condor-cron.running-service'] = False
 
         core.skip_ok_unless_installed('condor-cron')
-        if self.is_running():
+        if service.is_running('condor-cron'):
             core.state['condor-cron.running-service'] = True
             self.skip_ok('already running')
 
@@ -31,7 +21,7 @@ class TestStartCondorCron(osgunittest.OSGTestCase):
         else:
             core.check_system(('systemctl', 'start', 'condor-cron'), 'Start Condor-Cron')
 
-        self.assert_(self.is_running(), "Condor-Cron is not running")
+        self.assert_(service.is_running('condor-cron'), "Condor-Cron is not running")
 
         core.state['condor-cron.started-service'] = True
         core.state['condor-cron.running-service'] = True

--- a/osgtest/tests/test_88_condor_cron.py
+++ b/osgtest/tests/test_88_condor_cron.py
@@ -4,21 +4,28 @@ import osgtest.library.osgunittest as osgunittest
 import unittest
 
 class TestStopCondorCron(osgunittest.OSGTestCase):
+    def is_running(self):
+        # TODO Move this to library/service.py
+        if core.el_release() < 7:
+            command = ['service', 'condor-cron', 'status']
+        else:
+            command = ['systemctl', 'is-active', 'condor-cron']
+
+        status, _, _ = core.system(command)
+
+        return status == 0
 
     def test_01_stop_condor_cron(self):
         core.skip_ok_unless_installed('condor-cron')
         self.skip_ok_if(core.state['condor-cron.started-service'] == False, 'did not start server')
 
-
         if core.el_release() < 7:
             command = ('service', 'condor-cron', 'stop')
             stdout, _, fail = core.check_system(command, 'Stop Condor-Cron')
             self.assert_(stdout.find('error') == -1, fail)
-            self.assert_(not os.path.exists(core.config['condor-cron.lockfile']),
-                         'Condor-Cron run lock file still present')
         else:
             core.check_system(('systemctl', 'stop', 'condor-cron'), 'Stop Condor-Cron')
-            status, _, _ = core.system(('systemctl', 'is-active', 'condor-cron'))
-            self.assertNotEqual(status, 0, 'Condor-Cron still active')
 
-    core.state['condor-cron.running-service'] = False
+        self.assertFalse(self.is_running(), 'Condor-Cron still active')
+
+        core.state['condor-cron.running-service'] = False

--- a/osgtest/tests/test_88_condor_cron.py
+++ b/osgtest/tests/test_88_condor_cron.py
@@ -1,20 +1,10 @@
 import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
 import unittest
 
 class TestStopCondorCron(osgunittest.OSGTestCase):
-    def is_running(self):
-        # TODO Move this to library/service.py
-        if core.el_release() < 7:
-            command = ['service', 'condor-cron', 'status']
-        else:
-            command = ['systemctl', 'is-active', 'condor-cron']
-
-        status, _, _ = core.system(command)
-
-        return status == 0
-
     def test_01_stop_condor_cron(self):
         core.skip_ok_unless_installed('condor-cron')
         self.skip_ok_if(core.state['condor-cron.started-service'] == False, 'did not start server')
@@ -26,6 +16,6 @@ class TestStopCondorCron(osgunittest.OSGTestCase):
         else:
             core.check_system(('systemctl', 'stop', 'condor-cron'), 'Stop Condor-Cron')
 
-        self.assertFalse(self.is_running(), 'Condor-Cron still active')
+        self.assertFalse(service.is_running('condor-cron'), 'Condor-Cron still active')
 
         core.state['condor-cron.running-service'] = False


### PR DESCRIPTION
Use systemctl commands for starting/stopping condor-cron. In addition, determine the status of the process by using `systemctl is-active` on EL 7 and `service ... status` on EL 6, instead of looking for a lock file. This fixes errors caused by the removal of the condor-cron init script in SOFTWARE-2439.

The results of a VMU test run are here: http://vdt.cs.wisc.edu/tests/20160921-0857/packages.html