### PR TITLE
Fully support systemd in the service library

### DIFF
--- a/osgtest/library/condor.py
+++ b/osgtest/library/condor.py
@@ -20,24 +20,10 @@ def lockfile_path():
     return condor_lockfile
 
 
-def is_running():
-    """True if condor is running, False otherwise
-    On EL5 and EL6, tests the existence of a lockfile. On EL7, runs
-    'service condor status'
-
-    """
-    condor_lockfile = lockfile_path()
-    if condor_lockfile is not None:
-        return os.path.exists(condor_lockfile)
-    else:
-        # In EL7 we no longer have a lockfile
-        returncode, _, _ = core.system(['service', 'condor', 'status'])
-        return returncode == 0
-
 def wait_for_daemon(collector_log_path, stat, daemon, timeout):
     """Wait until the requested 'daemon' is available and accepting commands by
     monitoring the specified CollectorLog from the position specified by 'stat'
-    for a maximum of 'timeout' seconds. Returns True if the daemon becomes 
+    for a maximum of 'timeout' seconds. Returns True if the daemon becomes
     available within the timeout period and False, otherwise.
 
     """

--- a/osgtest/library/service.py
+++ b/osgtest/library/service.py
@@ -1,5 +1,6 @@
 """Utilities for starting and stopping init-based services."""
 import os
+import time
 
 import osgtest.library.core as core
 
@@ -99,7 +100,7 @@ def stop(service_name):
 
     core.state[service_name + '.started-service'] = False
 
-def is_running(service_name, init_script=None):
+def is_running(service_name, init_script=None, timeout=5):
     """Detect if a service is running via an init script
 
     Globals used:
@@ -113,7 +114,14 @@ def is_running(service_name, init_script=None):
     else:
         command = ('service', init_script, 'status')
 
-    status, _, _ = core.system(command, 'Checking status of ' + service_name + ' service')
+    timer = 0
+    status = None
+    while timer < timeout:
+        # Don't exit loop based on status since we use this function
+        # to also check to ensure that the service gets stopped properly
+        status, _, _ = core.system(command, 'Checking status of ' + service_name + ' service')
+        time.sleep(1)
+        timer += 1
 
     return status == 0
 

--- a/osgtest/library/service.py
+++ b/osgtest/library/service.py
@@ -116,10 +116,11 @@ def is_running(service_name, init_script=None, timeout=5):
 
     timer = 0
     status = None
+
     while timer < timeout:
         # Don't exit loop based on status since we use this function
         # to also check to ensure that the service gets stopped properly
-        status, _, _ = core.system(command, 'Checking status of ' + service_name + ' service')
+        status, _, _ = core.system(command)
         time.sleep(1)
         timer += 1
 

--- a/osgtest/tests/test_10_condor.py
+++ b/osgtest/tests/test_10_condor.py
@@ -1,9 +1,8 @@
 import os
 import osgtest.library.core as core
-import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.condor as condor
-
+import osgtest.library.service as service
 
 class TestStartCondor(osgunittest.OSGTestCase):
 
@@ -15,14 +14,13 @@ class TestStartCondor(osgunittest.OSGTestCase):
                                                                'Failed to query for Condor CollectorLog path')[0]\
                                                  .strip()
 
-        if condor.is_running():
+        if service.is_running('condor'):
             core.state['condor.running-service'] = True
-            self.skip_ok('already running')
+            return
 
-        command = ('service', 'condor', 'start')
-        stdout, _, fail = core.check_system(command, 'Start Condor')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(condor.is_running(), 'Condor not running after we started it')
+        service.start('condor')
+        self.assert_(service.is_running('condor'), 'Condor not running after we started it')
+        core.state['condor.started-service'] = True
         core.state['condor.running-service'] = True
 
         try:

--- a/osgtest/tests/test_10_condor.py
+++ b/osgtest/tests/test_10_condor.py
@@ -1,7 +1,6 @@
 import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
-import osgtest.library.condor as condor
 import osgtest.library.service as service
 
 class TestStartCondor(osgunittest.OSGTestCase):
@@ -18,12 +17,12 @@ class TestStartCondor(osgunittest.OSGTestCase):
             core.state['condor.running-service'] = True
             return
 
-        service.start('condor')
-        self.assert_(service.is_running('condor'), 'Condor not running after we started it')
-        core.state['condor.started-service'] = True
-        core.state['condor.running-service'] = True
-
         try:
             core.config['condor.collectorlog_stat'] = os.stat(core.config['condor.collectorlog'])
         except OSError:
             core.config['condor.collectorlog_stat'] = None
+
+        service.start('condor')
+        self.assert_(service.is_running('condor'), 'Condor not running after we started it')
+        core.state['condor.started-service'] = True
+        core.state['condor.running-service'] = True

--- a/osgtest/tests/test_11_condor_cron.py
+++ b/osgtest/tests/test_11_condor_cron.py
@@ -2,8 +2,6 @@ import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
-import time
-import unittest
 
 class TestStartCondorCron(osgunittest.OSGTestCase):
     def test_01_start_condor_cron(self):
@@ -15,17 +13,8 @@ class TestStartCondorCron(osgunittest.OSGTestCase):
             core.state['condor-cron.running-service'] = True
             self.skip_ok('already running')
 
-        if core.el_release() < 7:
-            command = ('service', 'condor-cron', 'start')
-            stdout, _, fail = core.check_system(command, 'Start Condor-Cron')
-            self.assert_(stdout.find('error') == -1, fail)
-        else:
-            core.check_system(('systemctl', 'start', 'condor-cron'), 'Start Condor-Cron')
-
-        # Give condor-cron time to start up
-        time.sleep(5)
-
-        self.assert_(service.is_running('condor-cron'), "Condor-Cron is not running")
+        service.start('condor-cron')
+        self.assert_(service.is_running('condor-cron', timeout=5), "Condor-Cron is not running")
 
         core.state['condor-cron.started-service'] = True
         core.state['condor-cron.running-service'] = True

--- a/osgtest/tests/test_12_gatekeeper.py
+++ b/osgtest/tests/test_12_gatekeeper.py
@@ -37,11 +37,9 @@ class TestStartGatekeeper(osgunittest.OSGTestCase):
         # https://jira.opensciencegrid.org/browse/SOFTWARE-1929
         self.skip_ok_if(core.el_release() == 5, 'Disable the SEG for EL5')
         self.skip_ok_if(os.path.exists(core.config['globus.seg-lockfile']), 'SEG already running')
-        command = ('service', 'globus-scheduler-event-generator', 'start')
-        stdout, _, fail = core.check_system(command, 'Start Globus SEG')
-        self.assert_(stdout.find('FAILED') == -1, fail)
-        self.assert_(os.path.exists(core.config['globus.seg-lockfile']),
-                     'Globus SEG run lock file missing')
+
+        service.start('globus-scheduler-event-generator')
+        self.assert_(service.is_running('globus-scheduler-event-generator'), 'Globus SEG failed to start')
         core.state['globus.started-seg'] = True
 
     def test_03_configure_globus_pbs(self):

--- a/osgtest/tests/test_15_xrootd.py
+++ b/osgtest/tests/test_15_xrootd.py
@@ -2,6 +2,7 @@ import os
 import pwd
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 XROOTD_CFG_TEXT = """\
@@ -56,12 +57,11 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             core.state['xrootd.backups-exist'] = True
 
         if core.el_release() < 7:
-            stdout, _, fail = core.check_system(('service', 'xrootd', 'start'), 'Start Xrootd server')
-            self.assert_('FAILED' not in stdout, fail)
-            self.assert_(os.path.exists(core.config['xrootd.pid-file']), 'Xrootd server PID file missing')
+            core.config['xrootd_service'] = "xrootd"
         else:
-            core.check_system(('systemctl', 'start', 'xrootd@clustered'), 'Start Xrootd server')
-            core.check_system(('systemctl', 'status', 'xrootd@clustered'), 'Verify status of Xrootd server')
+            core.config['xrootd_service'] = "xrootd@clustered"
 
+        service.start(core.config['xrootd_service'])
+        self.assert_(service.is_running(core.config['xrootd_service']), 'XRootD failed to start')
         core.state['xrootd.started-server'] = True
 

--- a/osgtest/tests/test_16_rsv.py
+++ b/osgtest/tests/test_16_rsv.py
@@ -1,7 +1,6 @@
 import os
-import unittest
 
-from osgtest.library import core, osgunittest
+from osgtest.library import core, service, osgunittest
 
 class TestStartRSV(osgunittest.OSGTestCase):
 
@@ -23,11 +22,8 @@ class TestStartRSV(osgunittest.OSGTestCase):
         # Before we start RSV, make sure Condor-Cron is up
         self.skip_bad_unless(core.state['condor-cron.running-service'], 'Condor-Cron not running')
 
-        command = ('service', 'rsv', 'start')
-        stdout, _, fail = core.check_system(command, 'Start RSV')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(os.path.exists(core.config['rsv.lockfile']),
-                     'RSV run lock file missing')
+        service.start('rsv')
+        self.assert_(service.is_running('rsv'), 'RSV failed to start')
 
         core.state['rsv.started-service'] = True
         core.state['rsv.running-service'] = True

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -6,6 +6,7 @@ import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.condor as condor
+import osgtest.library.service as service
 
 class TestStartCondorCE(osgunittest.OSGTestCase):
     # Tests 01-02 are needed to reconfigure condor to work with HTCondor-CE
@@ -33,7 +34,7 @@ class TestStartCondorCE(osgunittest.OSGTestCase):
 
         command = ('condor_reconfig', '-debug')
         core.check_system(command, 'Reconfigure Condor')
-        self.assert_(condor.is_running(), 'Condor not running after reconfig')
+        self.assert_(service.is_running('condor'), 'Condor not running after reconfig')
 
     def test_03_configure_authentication(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')

--- a/osgtest/tests/test_22_myproxy.py
+++ b/osgtest/tests/test_22_myproxy.py
@@ -2,6 +2,7 @@ import os
 
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStartMyProxy(osgunittest.OSGTestCase):
@@ -23,11 +24,11 @@ class TestStartMyProxy(osgunittest.OSGTestCase):
     def test_03_config_myproxy(self):
         core.skip_ok_unless_installed('myproxy-server')
         conFileContents = files.read('/usr/share/osg-test/test_myproxy_server.config')
-        files.write('/etc/myproxy-server.config',conFileContents, owner='root', backup=True)  
+        files.write('/etc/myproxy-server.config', conFileContents, owner='root', backup=True)
         if core.el_release() <= 6:
-            core.config['myproxy.lock-file']='/var/lock/subsys/myproxy-server'
+            core.config['myproxy.lock-file'] = '/var/lock/subsys/myproxy-server'
         else:
-            core.config['myproxy.lock-file']='/var/run/myproxy-server/myproxy.pid'
+            core.config['myproxy.lock-file'] = '/var/run/myproxy-server/myproxy.pid'
 
     def test_04_start_myproxy(self):
         core.state['myproxy.started-server'] = False
@@ -35,11 +36,7 @@ class TestStartMyProxy(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('myproxy-server')
         self.skip_ok_if(os.path.exists(core.config['myproxy.lock-file']), 'apparently running')
 
-        command = ('service', 'myproxy-server', 'start')
-        stdout, _, fail = core.check_system(command, 'Start myproxy-server service')
-        self.assertEqual(stdout.find('FAILED'), -1, fail)
-        self.assert_(os.path.exists(core.config['myproxy.lock-file']),
-                     'myproxy server PID file is missing')
+        service.start('myproxy-server')
+        self.assert_(service.is_running('myproxy-server'), 'MyProxy failed to start')
         core.state['myproxy.started-server'] = True
 
-    

--- a/osgtest/tests/test_26_bestman.py
+++ b/osgtest/tests/test_26_bestman.py
@@ -1,6 +1,7 @@
 import os
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStartBestman(osgunittest.OSGTestCase):
@@ -77,11 +78,7 @@ class TestStartBestman(osgunittest.OSGTestCase):
         core.state['bestman.server-running'] = False
 
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')
-        retcode, _, _ = core.system(('service', 'bestman2', 'status'))
-        # bestman2 init script follows LSB standards for return codes:
-        # 0 = running, 1 = not running, 3 = stale pidfile (i.e. it crashed)
-        # We want to start it up if it's not running or had crashed
-        if retcode == 0:
+        if service.is_running('bestman2'):
             core.state['bestman.server-running'] = True
             self.skip_ok('apparently running')
 
@@ -91,18 +88,9 @@ class TestStartBestman(osgunittest.OSGTestCase):
             for logfile in ('bestman2.log', 'event.srm.log'):
                 core.system(('cat', os.path.join(logdir, logfile)))
 
-        command = ('service', 'bestman2', 'start')
+        service.start('bestman2')
         try:
-            stdout, _, fail = core.check_system(command, 'Starting bestman2')
-            self.assert_(stdout.find('FAILED') == -1, fail)
-            self.assert_(os.path.exists(core.config['bestman.pid-file']),
-                         'Bestman server PID file missing')
-            # 'service bestman2 status' checks if the process mentioned in the pid
-            # file is actually running, which can detect if bestman crashed right
-            # after startup. In theory it's vulnerable to problems caused by pid
-            # re-use, but those are unlikely
-            command = ('service', 'bestman2', 'status')
-            stdout, _, fail = core.check_system(command, 'Verifying bestman2 started')
+            self.assert_(service.is_running('bestman2'), 'Bestman failed to start')
         except AssertionError:
             _dump_logfiles()
             raise

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -99,7 +99,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
     def test_05_condor_ce_run_condor(self):
         core.skip_ok_unless_installed('htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor', 'condor')
 
-        self.skip_bad_unless(core.state['condor-ce.started'], 'ce not started')
+        self.skip_bad_unless(core.state['condor-ce.started-service'], 'ce not started')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
 
         command = ('condor_ce_run', '-r', '%s:9619' % core.get_hostname(), '/bin/env')

--- a/osgtest/tests/test_54_gratia.py
+++ b/osgtest/tests/test_54_gratia.py
@@ -418,7 +418,8 @@ class TestGratia(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('gratia-probe-condor', 'gratia-service')
         core.skip_ok_unless_one_installed('htcondor-ce-condor', 'globus-gram-job-manager-condor')
         self.skip_bad_if(core.state['gratia.condor-logs-copied'] == False)
-        self.skip_bad_unless(core.state['globus-gatekeeper.running'] or core.state['condor-ce.started'], 'gatekeeper not running')
+        self.skip_bad_unless(core.state['globus-gatekeeper.running'] or core.state['condor-ce.started-service'],
+                             'gatekeeper not running')
         self.skip_bad_unless(core.state['condor.running-service'], message='Condor service not running')
         if os.path.exists(core.config['gratia.log.file']):
             core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -12,7 +12,7 @@ import osgtest.library.osgunittest as osgunittest
 class TestCondorCE(osgunittest.OSGTestCase):
     def general_requirements(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
-        self.skip_bad_unless(core.state['condor-ce.started'], 'ce not running')
+        self.skip_bad_unless(core.state['condor-ce.started-service'], 'ce not running')
 
     def test_01_status(self):
         self.general_requirements()
@@ -60,9 +60,9 @@ class TestCondorCE(osgunittest.OSGTestCase):
         os.chdir(cwd)
 
     def test_06_use_gums_auth(self):
+        core.state['condor-ce.gums-auth'] = False
         self.general_requirements()
         core.skip_ok_unless_installed('gums-service')
-        core.state['condor-ce.gums-auth'] = False
 
         # Setting up GUMS auth using the instructions here:
         # twiki.grid.iu.edu/bin/view/Documentation/Release3/InstallComputeElement#8_1_Using_GUMS_for_Authorization

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -7,6 +7,7 @@ import re
 import osgtest.library.condor as condor
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestCondorCE(osgunittest.OSGTestCase):
@@ -106,11 +107,8 @@ gums.authz=https://%s:8443/gums/services/GUMSXACMLAuthorizationServicePort
                       'globus_mapping liblcas_lcmaps_gt4_mapping.so lcmaps_callout',
                       owner='condor-ce')
 
-        command = ('service', 'condor-ce', 'stop')
-        core.check_system(command, 'stop condor-ce')
-
-        command = ('service', 'condor-ce', 'start')
-        core.check_system(command, 'start condor-ce')
+        service.stop('condor-ce')
+        service.start('condor-ce')
         core.state['condor-ce.gums-auth'] = True
 
     def test_07_ping_with_gums(self):

--- a/osgtest/tests/test_76_tomcat.py
+++ b/osgtest/tests/test_76_tomcat.py
@@ -18,10 +18,8 @@ class TestStopTomcat(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('voms-admin-server')
         self.skip_ok_unless(core.state['voms.installed-vo-webapp'], 'did not start webapp')
 
-        command = ('service', 'voms-admin', 'stop')
-        core.check_system(command, 'Uninstall VOMS Admin webapp(s)')
-        self.assert_(not os.path.exists(core.config['voms.vo-webapp']),
-                     'VOMS Admin VO context file still exists')
+        service.stop('voms-admin')
+        self.assert_(not service.is_running('voms-admin'), 'VOMS admin failed to stop')
 
     def test_03_deconfig_tomcat_properties(self):
         core.skip_ok_unless_installed(tomcat.pkgname(), 'emi-trustmanager-tomcat')

--- a/osgtest/tests/test_77_myproxy.py
+++ b/osgtest/tests/test_77_myproxy.py
@@ -1,14 +1,6 @@
-import glob
-import os
-import pwd
-import re
-import shutil
-import socket
-import time
-import unittest
-
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStopMyProxy(osgunittest.OSGTestCase):
@@ -18,11 +10,8 @@ class TestStopMyProxy(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('myproxy-server')
         self.skip_ok_unless(core.state['myproxy.started-server'], 'did not start server')
 
-        command = ('service', 'myproxy-server', 'stop')
-        stdout, stderr, fail = core.check_system(command, 'Stop myproxy server')
-        self.assertEqual(stdout.find('FAILED'), -1, fail)
-        self.assert_(not os.path.exists(core.config['myproxy.lock-file']),
-                     'myproxy server lock file still exists')
+        service.stop('myproxy-server')
+        self.assert_(not service.is_running('myproxy-server'), 'MyProxy failed to stop')
 
 
     def test_02_restore_configFile(self):

--- a/osgtest/tests/test_78_voms.py
+++ b/osgtest/tests/test_78_voms.py
@@ -1,8 +1,6 @@
-import os
-import shutil
-
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.voms as voms
 
@@ -15,16 +13,8 @@ class TestStopVOMS(osgunittest.OSGTestCase):
         voms.skip_ok_unless_installed()
         self.skip_ok_unless(core.state['voms.started-server'], 'did not start server')
 
-        if core.el_release() < 7:
-            command = ('service', 'voms', 'stop')
-            stdout, _, fail = core.check_system(command, 'Stop VOMS server')
-            self.assertEqual(stdout.find('FAILED'), -1, fail)
-            self.assert_(not os.path.exists(core.config['voms.lock-file']),
-                         'VOMS server lock file still exists')
-        else:
-            core.check_system(('systemctl', 'stop', 'voms@' + core.config['voms.vo']), 'Stop VOMS server')
-            status, _, _ = core.system(('systemctl', 'is-active', 'voms@' + core.config['voms.vo']))
-            self.assertNotEqual(status, 0, 'VOMS server still active')
+        service.stop(core.config['voms_service'])
+        self.assert_(not service.is_running(core.config['voms_service']), 'VOMS failed to stop')
 
     def test_02_restore_vomses(self):
         voms.skip_ok_unless_installed()

--- a/osgtest/tests/test_79_condorce.py
+++ b/osgtest/tests/test_79_condorce.py
@@ -1,23 +1,20 @@
-import os
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStopCondorCE(osgunittest.OSGTestCase):
     def test_01_stop_condorce(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor')
-        self.skip_ok_unless(core.state['condor-ce.started'], 'did not start server')
+        self.skip_ok_unless(core.state['condor-ce.started-service'], 'did not start server')
 
-        command = ('service', 'condor-ce', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop HTCondor CE')
-        self.assert_(stdout.find('FAILED') == -1, fail)
-        self.assert_(not os.path.exists(core.config['condor-ce.lockfile']),
-                     'HTCondor CE run lock file exists')
+        service.stop('condor-ce')
+        self.assert_(not service.is_running('condor-ce'), 'HTCondor-CE still running')
 
     def test_02_restore_config(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor')
 
-        if core.rpm_is_installed('gums-service'):
+        if core.rpm_is_installed('gums-service') and core.state['condor-ce.gums-auth']:
             files.restore(core.config['condor-ce.lcmapsdb'], 'condor-ce.gums')
             files.restore(core.config['condor-ce.gsi-authz'], 'condor-ce')
             files.restore(core.config['condor-ce.gums-properties'], 'condor-ce')

--- a/osgtest/tests/test_83_rsv.py
+++ b/osgtest/tests/test_83_rsv.py
@@ -1,8 +1,6 @@
-import os
-import unittest
-
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStopRSV(osgunittest.OSGTestCase):
@@ -11,11 +9,8 @@ class TestStopRSV(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('rsv')
         self.skip_ok_if(core.state['rsv.started-service'] == False, 'did not start service')
 
-        command = ('service', 'rsv', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop RSV')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(not os.path.exists(core.config['rsv.lockfile']),
-                     'RSV run lock file still present')
+        service.stop('rsv')
+        self.assert_(not service.is_running('rsv'), 'RSV failed to stop')
 
         core.state['rsv.running-service'] = False
 

--- a/osgtest/tests/test_84_xrootd.py
+++ b/osgtest/tests/test_84_xrootd.py
@@ -1,26 +1,17 @@
-import os
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
-import unittest
 
 class TestStopXrootd(osgunittest.OSGTestCase):
 
     def test_01_stop_xrootd(self):
         if (core.config['xrootd.gsi'] == "ON") and (core.state['xrootd.backups-exist'] == True):
-            files.restore('/etc/xrootd/xrootd-clustered.cfg',"xrootd")
-            files.restore('/etc/xrootd/auth_file',"xrootd")
-            files.restore('/etc/grid-security/xrd/xrdmapfile',"xrootd")
+            files.restore('/etc/xrootd/xrootd-clustered.cfg', "xrootd")
+            files.restore('/etc/xrootd/auth_file', "xrootd")
+            files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")
         core.skip_ok_unless_installed('xrootd', by_dependency=True)
         self.skip_ok_if(core.state['xrootd.started-server'] == False, 'did not start server')
 
-        if core.el_release() < 7:
-            command = ('service', 'xrootd', 'stop')
-            stdout, _, fail = core.check_system(command, 'Stop Xrootd server')
-            self.assert_(stdout.find('FAILED') == -1, fail)
-            self.assert_(not os.path.exists(core.config['xrootd.pid-file']),
-                         'Xrootd server PID file still present')
-        else:
-            core.check_system(('systemctl', 'stop', 'xrootd@clustered'), 'Stop Xrootd server')
-
-            core.check_system(('systemctl', 'status', 'xrootd@clustered'), 'Verify Xrootd server stopped', exit=3)
+        service.stop(core.config['xrootd_service'])
+        self.assert_(not service.is_running(core.config['xrootd_service']), 'XRootD failed to stop')

--- a/osgtest/tests/test_87_gatekeeper.py
+++ b/osgtest/tests/test_87_gatekeeper.py
@@ -1,9 +1,8 @@
-import os
 import osgtest.library.core as core
 import osgtest.library.service as service
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
-import unittest
+
 
 class TestStopGatekeeper(osgunittest.OSGTestCase):
 
@@ -18,12 +17,8 @@ class TestStopGatekeeper(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('globus-scheduler-event-generator-progs')
         self.skip_ok_if(core.state['globus.started-seg'] == False, 'SEG apparently running')
 
-        command = ('service', 'globus-scheduler-event-generator', 'stop')
-        stdout, _, fail = core.check_system(command, 'Start Globus SEG')
-        self.assert_(stdout.find('FAILED') == -1, fail)
-        self.assert_(not os.path.exists(core.config['globus.seg-lockfile']),
-                     'Globus SEG run lock file still present')
-        core.state['globus.started-seg'] = False
+        service.stop('globus-scheduler-event-generator')
+        self.assert_(not service.is_running('globus-scheduler-event-generator'), 'Globus SEG failed to stop')
 
     def test_03_configure_globus_pbs(self):
         self.skip_ok_unless(core.state['globus.pbs_configured'], 'Globus pbs configuration not altered')

--- a/osgtest/tests/test_88_condor_cron.py
+++ b/osgtest/tests/test_88_condor_cron.py
@@ -1,21 +1,13 @@
-import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
-import unittest
 
 class TestStopCondorCron(osgunittest.OSGTestCase):
     def test_01_stop_condor_cron(self):
         core.skip_ok_unless_installed('condor-cron')
         self.skip_ok_if(core.state['condor-cron.started-service'] == False, 'did not start server')
 
-        if core.el_release() < 7:
-            command = ('service', 'condor-cron', 'stop')
-            stdout, _, fail = core.check_system(command, 'Stop Condor-Cron')
-            self.assert_(stdout.find('error') == -1, fail)
-        else:
-            core.check_system(('systemctl', 'stop', 'condor-cron'), 'Stop Condor-Cron')
-
+        service.stop('condor-cron')
         self.assertFalse(service.is_running('condor-cron'), 'Condor-Cron still active')
 
         core.state['condor-cron.running-service'] = False

--- a/osgtest/tests/test_89_condor.py
+++ b/osgtest/tests/test_89_condor.py
@@ -1,19 +1,15 @@
-import os
 import osgtest.library.core as core
-import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
-import osgtest.library.condor as condor
 
 class TestStopCondor(osgunittest.OSGTestCase):
 
     def test_01_stop_condor(self):
         core.skip_ok_unless_installed('condor')
-        self.skip_ok_if(core.state['condor.running-service'] == False, 'did not start server')
+        self.skip_ok_if(core.state['condor.started-service'] == False, 'did not start server')
 
-        command = ('service', 'condor', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop Condor')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(not condor.is_running(),
+        service.stop('condor')
+        self.assert_(not service.is_running('condor'),
                      'Condor still running after stop')
 
         core.state['condor.running-service'] = False

--- a/osgtest/tests/test_90_bestman.py
+++ b/osgtest/tests/test_90_bestman.py
@@ -1,8 +1,6 @@
-import os
-import unittest
-
 import osgtest.library.core as core
 import osgtest.library.files as files
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStopBestman(osgunittest.OSGTestCase):
@@ -10,11 +8,9 @@ class TestStopBestman(osgunittest.OSGTestCase):
     def test_01_stop_bestman(self):
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')
         self.skip_ok_unless(core.state['bestman.started-server'], 'bestman server not started')
-        command = ('service', 'bestman2', 'stop')
-        stdout, _, fail = core.check_system(command, 'Shutting down bestman2')
-        self.assert_(stdout.find('FAILED') == -1, fail)
-        self.assert_(not os.path.exists(core.config['bestman.pid-file']),
-                     'Bestman server PID file still present')
+
+        service.stop('bestman2')
+        self.assert_(not service.is_running('bestman2'), 'Bestman failed to stop')
 
     def test_02_deconfig_sudoers(self):
         if core.missing_rpm('bestman2-server', 'bestman2-client'):

--- a/osgtest/tests/test_91_pbs.py
+++ b/osgtest/tests/test_91_pbs.py
@@ -1,4 +1,3 @@
-import os
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
@@ -16,11 +15,8 @@ class TestStopPBS(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(core.state['torque.pbs-mom-running'] == False, 'did not start pbs mom server')
 
-        command = ('service', 'pbs_mom', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop pbs mom')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(not os.path.exists(core.config['torque.mom-lockfile']),
-                     'PBS mom run lock file still present')
+        service.stop('pbs_mom')
+        self.assert_(not service.is_running('pbs_mom'), 'PBS mom failed to stop')
 
         for mom_file in ['config', 'layout']:
             files.restore(core.config['torque.mom-%s' % mom_file], 'pbs')
@@ -30,11 +26,8 @@ class TestStopPBS(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(core.state['torque.pbs-server-started'] == False, 'did not start pbs server')
 
-        command = ('service', 'pbs_server', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop pbs server')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(not os.path.exists(core.config['torque.pbs-lockfile']),
-                     'PBS server run lock file still present')
+        service.stop('pbs_server')
+        self.assert_(not service.is_running('pbs_server'), 'PBS server failed to stop')
 
         if core.state['trqauthd.started-service']:
             service.stop('trqauthd')
@@ -47,11 +40,8 @@ class TestStopPBS(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(core.state['torque.pbs-sched-running'] == False, 'did not start pbs scheduler')
 
-        command = ('service', 'pbs_sched', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop pbs scheduler')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(not os.path.exists(core.config['torque.sched-lockfile']),
-                     'PBS server run lock file still present')
+        service.stop('pbs_sched')
+        self.assert_(not service.is_running('pbs_sched'), 'PBS sched failed to stop')
 
         core.state['torque.pbs-sched-running'] = False
 
@@ -59,11 +49,9 @@ class TestStopPBS(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(core.state['munge.running'] == False, 'munge not running')
 
-        command = ('service', 'munge', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop munge daemon')
-        self.assert_(stdout.find('error') == -1, fail)
-        self.assert_(not os.path.exists(core.config['munge.lockfile']),
-                     'munge lock file still present')
+        service.stop('munge')
+        self.assert_(not service.is_running('munge'), 'munge failed to stop')
+
         core.state['munge.running'] = False
         files.restore(core.config['munge.keyfile'], 'pbs')
 


### PR DESCRIPTION
This fixes the globus-gatekeeper startup issues in the tests. A rather large set of changes as it moves almost all ([GridFTP has a broken response to `status`](https://jira.opensciencegrid.org/browse/SOFTWARE-2470?filter=12359)) tests to the new service commands; I'd suggest reviewing commit by commit as the files changed are mostly exclusive to and grouped by commits. Let me know if there are any questions at all.

Test results: http://vdt.cs.wisc.edu/tests/20160928-1353/results.html