### PR TITLE
Temporary fix to handle broken CE 2.0.8 to 2.0.9 updates

### DIFF
--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -94,12 +94,15 @@ gridmapfile -> good | bad
         core.state['condor-ce.schedd-ready'] = False
 
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
-        self.skip_ok_if(service.is_running('condor-ce'), 'already running')
-        service.start('condor-ce')
-
         collector_log, _, _ = core.check_system(('condor_ce_config_val', 'COLLECTOR_LOG'),
                                                 'Failed to query for Condor CE CollectorLog path')
         core.config['condor-ce.collectorlog'] = collector_log.strip().strip()
+
+        if service.is_running('condor-ce'):
+            core.state['condor-ce.schedd-ready'] = True
+            self.skip_ok('already running')
+        service.start('condor-ce')
+
         try:
             stat = os.stat(core.config['condor-ce.collectorlog'])
         except OSError:

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -99,6 +99,17 @@ gridmapfile -> good | bad
         core.config['condor-ce.collectorlog'] = collector_log.strip().strip()
 
         if service.is_running('condor-ce'):
+            # Required to accept changes to the mapfile, which caused
+            # issues in the nightly due to bad htcondor-ce-2.0.8-2
+            # packaging remove after OSG 3.3.17. We don't use service.stop()
+            # because it only stops services that we've started
+            if core.el_release() < 7:
+                command = ('service', 'condor-ce', 'stop')
+            else:
+                command = ('systemctl', 'stop', 'condor-ce')
+            core.check_system(command, 'Stop condor-ce service')
+            service.start('condor-ce')
+
             core.state['condor-ce.schedd-ready'] = True
             self.skip_ok('already running')
         service.start('condor-ce')

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -8,6 +8,7 @@ import shutil
 import tempfile
 
 import osgtest.library.core as core
+import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestRunJobs(osgunittest.OSGTestCase):
@@ -99,7 +100,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
     def test_05_condor_ce_run_condor(self):
         core.skip_ok_unless_installed('htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor', 'condor')
 
-        self.skip_bad_unless(core.state['condor-ce.started-service'], 'ce not started')
+        self.skip_bad_unless(service.is_running('condor-ce'), 'ce not running')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
 
         command = ('condor_ce_run', '-r', '%s:9619' % core.get_hostname(), '/bin/env')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -13,7 +13,7 @@ import osgtest.library.osgunittest as osgunittest
 class TestCondorCE(osgunittest.OSGTestCase):
     def general_requirements(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
-        self.skip_bad_unless(core.state['condor-ce.started-service'], 'ce not running')
+        self.skip_bad_unless(service.is_running('condor-ce'), 'ce not running')
 
     def test_01_status(self):
         self.general_requirements()


### PR DESCRIPTION
Update tests are broken because `htcondor-ce-2.0.8-2` unconditionally restarts on uninstallation so the CE tests see that the service is already running and subsequent CE tests are skipped. The service restart is a temporary fix (required to reload the `condor_mapfile` to accept our daemons using the generated host cert) to be removed when `htcondor-ce-2.0.9-3` is released so that we don't have a blind spot in the test coverage while it is in testing.

Test results: http://vdt.cs.wisc.edu/tests/20160929-1113/results.html