### PR TITLE
allow virtual dependencies for torque packages

### DIFF
--- a/osgtest/tests/test_17_pbs.py
+++ b/osgtest/tests/test_17_pbs.py
@@ -32,7 +32,7 @@ set server acl_host_enable = True
 
     def test_01_start_mom(self):
         core.state['pbs_mom.started-service'] = False
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_if(service.is_running('pbs_mom'), 'PBS mom already running')
 
         core.config['torque.mom-config'] = '/var/lib/torque/mom_priv/config'
@@ -47,14 +47,14 @@ set server acl_host_enable = True
 
     def test_02_start_pbs_sched(self):
         core.state['pbs_sched.started-service'] = False
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_if(service.is_running('pbs_sched'), 'PBS sched already running')
         service.check_start('pbs_sched')
 
     def test_03_start_trqauthd(self):
         core.state['trqauthd.started-service'] = False
         core.config['torque.pbs-servername-file'] = '/var/lib/torque/server_name'
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_if(service.is_running('trqauthd'), 'trqauthd is already running')
         # set hostname as servername instead of localhost
         # config required before starting trqauthd
@@ -66,7 +66,7 @@ set server acl_host_enable = True
     def test_04_configure_pbs(self):
         core.config['torque.pbs-nodes-file'] = '/var/lib/torque/server_priv/nodes'
         core.config['torque.pbs-serverdb'] = '/var/lib/torque/server_priv/serverdb'
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_bad_unless(service.is_running('trqauthd'), 'pbs_server requires trqauthd')
         self.skip_ok_if(service.is_running('pbs_server'), 'pbs server already running')
 
@@ -88,7 +88,7 @@ set server acl_host_enable = True
         core.state['pbs_server.started-service'] = False
         core.state['torque.nodes-up'] = False
 
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_bad_unless(service.is_running('trqauthd'), 'pbs_server requires trqauthd')
         self.skip_ok_if(service.is_running('pbs_server'), 'pbs server already running')
 

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -59,8 +59,8 @@ class TestRunJobs(osgunittest.OSGTestCase):
         self.verify_job_environment(stdout)
 
     def test_03_globus_run_pbs(self):
-        core.skip_ok_unless_installed('globus-gram-job-manager-pbs', 'globus-gram-client-tools', 'globus-proxy-utils',
-                                      'torque-mom', 'torque-server', 'torque-scheduler')
+        core.skip_ok_unless_installed('globus-gram-job-manager-pbs', 'globus-gram-client-tools', 'globus-proxy-utils')
+        core.skip_ok_unless_installed('torque-mom', 'torque-server', 'torque-scheduler', by_dependency=True)
         self.skip_bad_unless(core.state['globus-gatekeeper.running'], 'gatekeeper not running')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
         self.skip_bad_unless(service.is_running('pbs_server') and core.state['globus.pbs_configured'],
@@ -72,7 +72,8 @@ class TestRunJobs(osgunittest.OSGTestCase):
         self.verify_job_environment(stdout)
 
     def test_04_condor_run_pbs(self):
-        core.skip_ok_unless_installed('condor', 'blahp', 'torque-mom', 'torque-server', 'torque-scheduler')
+        core.skip_ok_unless_installed('condor', 'blahp')
+        core.skip_ok_unless_installed('torque-mom', 'torque-server', 'torque-scheduler', by_dependency=True)
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
         self.skip_bad_unless(service.is_running('condor'), 'condor not running')
         self.skip_bad_unless(service.is_running('pbs_server'), 'pbs not running')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -96,7 +96,8 @@ class TestCondorCE(osgunittest.OSGTestCase):
     def test_05_pbs_trace(self):
         self.general_requirements()
         self.skip_bad_unless(core.state['condor-ce.schedd-ready'], 'CE schedd not ready to accept jobs')
-        core.skip_ok_unless_installed('torque-mom', 'torque-server', 'torque-scheduler', 'torque-client', 'munge')
+        core.skip_ok_unless_installed('torque-mom', 'torque-server', 'torque-scheduler', 'torque-client', 'munge',
+                                      by_dependency=True)
         self.skip_ok_unless(service.is_running('pbs_server'))
         self.run_blahp_trace('pbs')
 

--- a/osgtest/tests/test_91_pbs.py
+++ b/osgtest/tests/test_91_pbs.py
@@ -12,27 +12,26 @@ class TestStopPBS(osgunittest.OSGTestCase):
                      'torque-client',
                      'munge']
 
-
     def test_01_stop_server(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_unless(core.state['pbs_server.started-service'], 'did not start pbs server')
         service.check_stop('pbs_server')
         files.restore(core.config['torque.pbs-serverdb'], 'pbs')
         files.restore(core.config['torque.pbs-nodes-file'], 'pbs')
 
     def test_02_stop_trqauthd(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_unless(core.state['trqauthd.started-service'], 'did not start trqauthd')
         service.check_stop('trqauthd')
         files.restore(core.config['torque.pbs-servername-file'], 'pbs')
 
     def test_03_stop_scheduler(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_unless(core.state['pbs_sched.started-service'], 'did not start pbs scheduler')
         service.check_stop('pbs_sched')
 
     def test_04_stop_mom(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
+        core.skip_ok_unless_installed(*self.required_rpms, by_dependency=True)
         self.skip_ok_unless(core.state['pbs_mom.started-service'], 'did not start pbs mom server')
         service.stop('pbs_mom')
 


### PR DESCRIPTION
Vaguely SOFTWARE-2484 related.

Apparently some (non-epel, oops) flavors of the torque/pbs packages have
a little different layout, and, for instance, 'torque-mom' is actually a
virtual capability provided by the 'torque-client' rpm.  In that case,
we really only care about 'torque-mom' as a dependency, not necessarily
as a package name.
