### PR TITLE
Check if edg-mkgridmap actually generates the grid-mapfile

### DIFF
--- a/osgtest/tests/test_51_edgmkgridmap.py
+++ b/osgtest/tests/test_51_edgmkgridmap.py
@@ -33,6 +33,7 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
         os.environ['VO_LIST_FILE'] = '/usr/share/osg-test/vo-list-file'
         os.environ['UNDEFINED_ACCTS_FILE'] = '/usr/share/osg-test/undef-ids'
         core.check_system(command, 'Run edg-mkgridmap')
+        self.assert_(os.path.exists(os.environ['GRIDMAP']), 'failed to generate grid-mapfile')
         core.system(('cat', os.environ['GRIDMAP']))
         core.system(('cat', os.environ['EDG_MKGRIDMAP_LOG']))
 


### PR DESCRIPTION
There was an error in the nightlies because `edg-mkgridmap` failed to actually generate a grid-mapfile:

```======================================================================
ERROR: test_02_edg_mkgridmap (osgtest.tests.test_51_edgmkgridmap.TestEdgMkGridmap)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/osgtest/library/osgunittest.py", line 165, in run
    testMethod()
  File "/usr/lib/python2.6/site-packages/osgtest/tests/test_51_edgmkgridmap.py", line 44, in test_02_edg_mkgridmap
    contents = files.read(os.environ['GRIDMAP'], True)
  File "/usr/lib/python2.6/site-packages/osgtest/library/files.py", line 38, in read
    the_file = open(path, 'r')
IOError: [Errno 2] No such file or directory: '/usr/share/osg-test/grid-mapfile'
```

Automated tests look clean: http://vdt.cs.wisc.edu/tests/20161027-1046/results.html

