### PR TITLE
Use service library for gridftp and add badskips if it can't be started

### DIFF
--- a/osgtest/tests/test_13_gridftp.py
+++ b/osgtest/tests/test_13_gridftp.py
@@ -1,20 +1,19 @@
 import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
-import unittest
+import osgtest.library.service as service
 
 class TestStartGridFTP(osgunittest.OSGTestCase):
 
     def test_01_start_gridftp(self):
-        core.config['gridftp.pid-file'] = '/var/run/globus-gridftp-server.pid'
         core.state['gridftp.started-server'] = False
+        core.state['gridftp.running-server'] = False
 
         core.skip_ok_unless_installed('globus-gridftp-server-progs')
-        self.skip_ok_if(os.path.exists(core.config['gridftp.pid-file']), 'already running')
+        if service.is_running('globus-gridftp-server'):
+            core.state['gridftp.running-server'] = True
+            return
 
-        command = ('service', 'globus-gridftp-server', 'start')
-        stdout, _, fail = core.check_system(command, 'Start GridFTP server')
-        self.assert_(stdout.find('FAILED') == -1, fail)
-        self.assert_(os.path.exists(core.config['gridftp.pid-file']),
-                     'GridFTP server PID file missing')
+        service.check_start('globus-gridftp-server')
+        core.state['gridftp.running-server'] = True
         core.state['gridftp.started-server'] = True

--- a/osgtest/tests/test_42_gridftp.py
+++ b/osgtest/tests/test_42_gridftp.py
@@ -14,6 +14,7 @@ class TestGridFTP(osgunittest.OSGTestCase):
     def test_01_copy_local_to_server(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'globus-ftp-client',
                                       'globus-proxy-utils', 'globus-gass-copy-progs')
+        self.skip_bad_unless(core.state['gridftp.running-server'] is True, 'GridFTP not running')
 
         hostname = socket.getfqdn()
         temp_dir = tempfile.mkdtemp()
@@ -33,6 +34,7 @@ class TestGridFTP(osgunittest.OSGTestCase):
     def test_02_copy_server_to_local(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'globus-ftp-client',
                                       'globus-proxy-utils', 'globus-gass-copy-progs')
+        self.skip_bad_unless(core.state['gridftp.running-server'] is True, 'GridFTP not running')
 
         hostname = socket.getfqdn()
         temp_dir = tempfile.mkdtemp()

--- a/osgtest/tests/test_43_uberftp.py
+++ b/osgtest/tests/test_43_uberftp.py
@@ -16,6 +16,7 @@ class TestUberFTP(osgunittest.OSGTestCase):
 
     def test_01_copy_local_to_server_uberftp(self):
         core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_bad_unless(core.state['gridftp.running-server'] is True, 'GridFTP not running')
 
         hostname = socket.getfqdn()
         temp_dir = tempfile.mkdtemp()
@@ -35,6 +36,7 @@ class TestUberFTP(osgunittest.OSGTestCase):
 
     def test_02_copy_server_to_local_uberftp(self):
         core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_bad_unless(core.state['gridftp.running-server'] is True, 'GridFTP not running')
 
         hostname = socket.getfqdn()
         temp_dir = tempfile.mkdtemp()
@@ -54,6 +56,7 @@ class TestUberFTP(osgunittest.OSGTestCase):
 
     def test_03_copy_local_to_server_uberftp_parallel(self):
         core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_bad_unless(core.state['gridftp.running-server'] is True, 'GridFTP not running')
 
         hostname = socket.getfqdn()
         temp_dir_source = tempfile.mkdtemp()
@@ -80,6 +83,7 @@ class TestUberFTP(osgunittest.OSGTestCase):
 
     def test_04_copy_server_to_local_uberftp_parallel(self):
         core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_bad_unless(core.state['gridftp.running-server'] is True, 'GridFTP not running')
 
         hostname = socket.getfqdn()
         temp_dir_source = tempfile.mkdtemp()

--- a/osgtest/tests/test_86_gridftp.py
+++ b/osgtest/tests/test_86_gridftp.py
@@ -1,16 +1,12 @@
 import os
 import osgtest.library.core as core
 import osgtest.library.osgunittest as osgunittest
-import unittest
+import osgtest.library.service as service
 
 class TestStopGridFTP(osgunittest.OSGTestCase):
 
     def test_01_stop_gridftp(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs')
         self.skip_ok_if(core.state['gridftp.started-server'] == False, 'did not start server')
-
-        command = ('service', 'globus-gridftp-server', 'stop')
-        stdout, _, fail = core.check_system(command, 'Stop GridFTP server')
-        self.assert_(stdout.find('FAILED') == -1, fail)
-        self.assert_(not os.path.exists(core.config['gridftp.pid-file']),
-                     'GridFTP server PID file still present')
+        service.check_stop('globus-gridftp-server')
+        core.state['gridftp.running-server'] = False


### PR DESCRIPTION
This requires the version of gridftp that was just released today, because of the init script exit status fix.

Test results are here: http://vdt.cs.wisc.edu/tests/20161108-1537/packages.html