### PR TITLE
Always define globus-gatekeeper.started-service state

### DIFF
--- a/osgtest/tests/test_12_gatekeeper.py
+++ b/osgtest/tests/test_12_gatekeeper.py
@@ -8,7 +8,7 @@ import osgtest.library.osgunittest as osgunittest
 class TestStartGatekeeper(osgunittest.OSGTestCase):
 
     def test_01_start_gatekeeper(self):
-        core.config['globus-gatekeeper.started-service'] = False
+        core.state['globus-gatekeeper.started-service'] = False
         core.state['globus-gatekeeper.running'] = False
         core.skip_ok_unless_installed('globus-gatekeeper')
         core.state['globus-gatekeeper.running'] = service.is_running('globus-gatekeeper')
@@ -25,7 +25,8 @@ class TestStartGatekeeper(osgunittest.OSGTestCase):
                 os.chmod('/var/log/globus', 0777)
 
             service.check_start('globus-gatekeeper')
-            core.state['globus-gatekeeper.running'] = service.is_running('globus-gatekeeper')
+            core.state['globus-gatekeeper.started-service'] = True
+            core.state['globus-gatekeeper.running'] = True
 
     def test_02_start_seg(self):
         core.state['globus.started-seg'] = False


### PR DESCRIPTION
Saw the following error in the nightlies:

```
  ERROR: test_01_stop_gatekeeper (osgtest.tests.test_87_gatekeeper.TestStopGatekeeper)
  ----------------------------------------------------------------------
  Traceback (most recent call last):
    File "/usr/lib/python2.7/site-packages/osgtest/library/osgunittest.py", line 165, in run
      testMethod()
    File "/usr/lib/python2.7/site-packages/osgtest/tests/test_87_gatekeeper.py", line 11, in test_01_stop_gatekeeper
      self.skip_ok_unless(core.state['globus-gatekeeper.started-service'], 'did not start gatekeeper')
  KeyError: 'globus-gatekeeper.started-service'
```

Test results look good here (some random, unrelated failures): http://vdt.cs.wisc.edu/tests/20161109-1412/results.html