### PR TITLE
catalina.CYMD.log dates are in UTC

### DIFF
--- a/osgtest/library/tomcat.py
+++ b/osgtest/library/tomcat.py
@@ -1,5 +1,5 @@
 import os
-from datetime import date
+import time
 
 import osgtest.library.core as core
 
@@ -43,7 +43,7 @@ def catalinafile():
     if majorver() <= 6:
         return os.path.join(logdir(), 'catalina.out')
     else:
-        return os.path.join(logdir(), 'catalina.%s.log' % date.strftime(date.today(), '%F'))
+        return os.path.join(logdir(), 'catalina.%s.log' % time.strftime('%F', time.gmtime()))
 
 def pidfile():
     "Path of pid file of a running Tomcat"


### PR DESCRIPTION
As @timtheisen explained, tomcat startup tests fail for jobs started
after 6pm CST, as the date in the catalina log file name is UTC, not
localtime.

Note that this fixes the issue with tests started between midnight UTC
(ie, 6pm CST) and midnight localtime, but does not handle the case where
a test starts just before midnight UTC, but the sentinel token is
written afterwards to a new log file for the next UTC date.
