### PR TITLE
Fix pbs server start

### DIFF
--- a/osgtest/tests/test_12_gatekeeper.py
+++ b/osgtest/tests/test_12_gatekeeper.py
@@ -30,14 +30,12 @@ class TestStartGatekeeper(osgunittest.OSGTestCase):
 
     def test_02_start_seg(self):
         core.state['globus.started-seg'] = False
-        core.config['globus.seg-lockfile'] = '/var/lock/subsys/globus-scheduler-event-generator'
-
         core.skip_ok_unless_installed('globus-scheduler-event-generator-progs')
         # globus-job-run against PBS hangs with the SEG so we disable it and use
         # globus-grid-job-manager-pbs-setup-poll instead
         # https://jira.opensciencegrid.org/browse/SOFTWARE-1929
         self.skip_ok_if(core.el_release() == 5, 'Disable the SEG for EL5')
-        self.skip_ok_if(os.path.exists(core.config['globus.seg-lockfile']), 'SEG already running')
+        self.skip_ok_if(service.is_running('globus-scheduler-event-generator'), 'SEG already running')
 
         service.check_start('globus-scheduler-event-generator')
         core.state['globus.started-seg'] = True

--- a/osgtest/tests/test_17_pbs.py
+++ b/osgtest/tests/test_17_pbs.py
@@ -22,7 +22,8 @@ set server scheduling=true
 set server acl_hosts += *
 set server acl_host_enable = True
 """
-    required_rpms = ['torque-mom',
+    required_rpms = ['torque',
+                     'torque-mom',
                      'torque-server',
                      'torque-scheduler',
                      'torque-client', # for qmgr
@@ -30,15 +31,8 @@ set server acl_host_enable = True
 
 
     def test_01_start_munge(self):
-        if core.el_release() == 5:
-            core.config['munge.lockfile'] = '/var/lock/subsys/munge'
-        elif core.el_release() == 6:
-            core.config['munge.lockfile'] = '/var/lock/subsys/munged'
-        elif core.el_release() == 7:
-            core.config['munge.lockfile'] = '/var/run/munge/munged.pid'
         core.config['munge.keyfile'] = '/etc/munge/munge.key'
-        core.state['munge.running'] = False
-
+        core.state['munge.started-service'] = False
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(service.is_running('munge'), 'already running')
 
@@ -46,17 +40,10 @@ set server acl_host_enable = True
         command = ('/usr/sbin/create-munge-key', '-f',)
         stdout, _, fail = core.check_system(command, 'Create munge key')
         self.assert_(stdout.find('error') == -1, fail)
-
         service.check_start('munge')
-        core.state['munge.running'] = True
 
     def test_02_start_mom(self):
-        if core.el_release() <= 6:
-            core.config['torque.mom-lockfile'] = '/var/lock/subsys/pbs_mom'
-        else:
-            core.config['torque.mom-lockfile'] = '/var/lib/torque/mom_priv/mom.lock'
-        core.state['torque.pbs-mom-running'] = False
-
+        core.state['pbs_mom.started-service'] = False
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(service.is_running('pbs_mom'), 'PBS mom already running')
 
@@ -68,61 +55,36 @@ set server acl_host_enable = True
         files.write(core.config['torque.mom-layout'],
                     "nodes=0",
                     owner='pbs')
-
         service.check_start('pbs_mom')
-        core.state['torque.pbs-mom-running'] = True
-
 
     def test_03_start_pbs_sched(self):
-        if core.el_release() <= 6:
-            core.config['torque.sched-lockfile'] = '/var/lock/subsys/pbs_sched'
-        else:
-            core.config['torque.sched-lockfile'] = '/var/lib/torque/sched_priv/sched.lock'
-        core.state['torque.pbs-sched-running'] = False
-
+        core.state['pbs_sched.started-service'] = False
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(service.is_running('pbs_sched'), 'PBS sched already running')
-
         service.check_start('pbs_sched')
-        core.state['torque.pbs-sched-running'] = True
 
-    def test_04_start_pbs(self):
-        if core.el_release() <= 6:
-            core.config['torque.pbs-lockfile'] = '/var/lock/subsys/pbs_server'
-        else:
-            core.config['torque.pbs-lockfile'] = '/var/lib/torque/server_priv/server.lock'
+    def test_04_start_trqauthd(self):
         core.state['trqauthd.started-service'] = False
-        core.state['torque.pbs-server-running'] = False
-        core.state['torque.pbs-server-started'] = False
-        core.state['torque.pbs-configured'] = False
-        core.state['torque.nodes-up'] = False
-        core.config['torque.pbs-nodes-file'] = '/var/lib/torque/server_priv/nodes'
         core.config['torque.pbs-servername-file'] = '/var/lib/torque/server_name'
-
         core.skip_ok_unless_installed(*self.required_rpms)
-        if os.path.exists(core.config['torque.pbs-lockfile']):
-            core.state['torque.pbs-server-running'] = True
-            self.skip_ok('pbs server apparently running')
-
+        self.skip_ok_if(service.is_running('trqauthd'), 'trqauthd is already running')
         # set hostname as servername instead of localhost
+        # config required before starting trqauthd
         files.write(core.config['torque.pbs-servername-file'],
                     "%s" % core.get_hostname(),
                     owner='pbs')
-        core.state['torque.pbs-configured'] = True
-
-        # trqauthd is required for the pbs_server
         service.check_start('trqauthd')
 
-        if not os.path.exists('/var/lib/torque/server_priv/serverdb'):
-            if core.el_release() <= 6:
-                command = 'service pbs_server create' # this creates the default config and starts the service
-            else:
-                # XXX: "service pbs_server create" doesn't work for systemd, and I haven't found a
-                #      systemd equivalent to do the "create" step in el7 ... The following was
-                #      distilled from the el6 init.d script:  (but please correct as necessary)
-                command = ('/usr/sbin/pbs_server -d /var/lib/torque -t create -f && '
-                           'sleep 10 && /usr/bin/qterm')
+    def test_05_configure_pbs(self):
+        core.config['torque.pbs-nodes-file'] = '/var/lib/torque/server_priv/nodes'
+        core.config['torque.pbs-serverdb'] = '/var/lib/torque/server_priv/serverdb'
+        core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_ok_if(service.is_running('pbs_server'), 'pbs server already running')
 
+        files.preserve(core.config['torque.pbs-serverdb'], 'pbs')
+        if not os.path.exists(core.config['torque.pbs-serverdb']):
+            command = ('/usr/sbin/pbs_server -d /var/lib/torque -t create -f && '
+                       'sleep 10 && /usr/bin/qterm')
             stdout, _, fail = core.check_system(command, 'create initial pbs serverdb config', shell=True)
             self.assert_(stdout.find('error') == -1, fail)
 
@@ -133,9 +95,13 @@ set server acl_host_enable = True
                     "%s np=1 num_node_boards=1\n" % core.get_hostname(),
                     owner='pbs')
 
-        # Sometimes the restart command throws an error on stop but still manages
-        # to kill the service, meaning that the service doesn't get brought back up
-        service.check_stop('pbs_server')
+    def test_06_start_pbs(self):
+        core.state['pbs_server.started-service'] = False
+        core.state['torque.nodes-up'] = False
+
+        core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_bad_unless(service.is_running('trqauthd'), 'pbs_server requires trqauthd')
+        self.skip_ok_if(service.is_running('pbs_server'), 'pbs server already running')
 
         server_log = '/var/log/torque/server_logs/' + date.today().strftime('%Y%m%d')
         try:
@@ -143,10 +109,7 @@ set server acl_host_enable = True
         except OSError:
             server_log_stat = None
 
-
         service.check_start('pbs_server')
-        core.state['torque.pbs-server-started'] = True
-        core.state['torque.pbs-server-running'] = True
 
         # Wait until the server is up before writing the rest of the config
         core.monitor_file(server_log, server_log_stat, '.*Server Ready.*', 60.0)

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -63,11 +63,8 @@ class TestRunJobs(osgunittest.OSGTestCase):
                                       'torque-mom', 'torque-server', 'torque-scheduler')
         self.skip_bad_unless(core.state['globus-gatekeeper.running'], 'gatekeeper not running')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
-        if (not core.state['torque.pbs-configured'] or
-            not core.state['torque.pbs-mom-running'] or
-            not core.state['torque.pbs-server-running'] or
-            not core.state['globus.pbs_configured']):
-            self.skip_bad('pbs not running or configured')
+        self.skip_bad_unless(service.is_running('pbs_server') and core.state['globus.pbs_configured'],
+                             'pbs not running or configured')
 
         # Verify job environments set in /var/lib/osg/osg-*job-environment.conf
         command = ('globus-job-run', self.contact_string('pbs'), '/bin/env')
@@ -77,9 +74,8 @@ class TestRunJobs(osgunittest.OSGTestCase):
     def test_04_condor_run_pbs(self):
         core.skip_ok_unless_installed('condor', 'blahp', 'torque-mom', 'torque-server', 'torque-scheduler')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
-        self.skip_bad_unless(core.state['condor.running-service'], 'condor not running')
-        self.skip_bad_unless(core.state['torque.pbs-mom-running'] and core.state['torque.pbs-server-running'],
-                             'pbs not running')
+        self.skip_bad_unless(service.is_running('condor'), 'condor not running')
+        self.skip_bad_unless(service.is_running('pbs_server'), 'pbs not running')
 
         command = ('condor_run', '-u', 'grid', '-a', 'grid_resource=pbs', '-a', 'periodic_remove=JobStatus==5',
                    '/bin/env')

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -95,7 +95,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor', 'condor')
 
         self.skip_bad_unless(service.is_running('condor-ce'), 'ce not running')
-        self.skip_bad_unless(service.is_running('condor'), 'ce not running')
+        self.skip_bad_unless(service.is_running('condor'), 'condor not running')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
 
         command = ('condor_ce_run', '-r', '%s:9619' % core.get_hostname(), '/bin/env')

--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -95,6 +95,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor', 'condor')
 
         self.skip_bad_unless(service.is_running('condor-ce'), 'ce not running')
+        self.skip_bad_unless(service.is_running('condor'), 'ce not running')
         self.skip_bad_unless(core.state['jobs.env-set'], 'job environment not set')
 
         command = ('condor_ce_run', '-r', '%s:9619' % core.get_hostname(), '/bin/env')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -51,7 +51,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
         self.general_requirements()
         self.skip_bad_unless(core.state['condor-ce.schedd-ready'], 'CE schedd not ready to accept jobs')
         core.skip_ok_unless_installed('torque-mom', 'torque-server', 'torque-scheduler', 'torque-client', 'munge')
-        self.skip_ok_unless(core.state['torque.pbs-server-running'])
+        self.skip_ok_unless(service.is_running('pbs_server'))
 
         cwd = os.getcwd()
         os.chdir('/tmp')

--- a/osgtest/tests/test_91_pbs.py
+++ b/osgtest/tests/test_91_pbs.py
@@ -5,48 +5,43 @@ import osgtest.library.service as service
 
 class TestStopPBS(osgunittest.OSGTestCase):
 
-    required_rpms = ['torque-mom',
+    required_rpms = ['torque',
+                     'torque-mom',
                      'torque-server',
                      'torque-scheduler',
                      'torque-client',
                      'munge']
 
-    def test_01_stop_mom(self):
+
+    def test_01_stop_server(self):
         core.skip_ok_unless_installed(*self.required_rpms)
-        self.skip_ok_if(core.state['torque.pbs-mom-running'] == False, 'did not start pbs mom server')
+        self.skip_ok_unless(core.state['pbs_server.started-service'], 'did not start pbs server')
+        service.check_stop('pbs_server')
+        files.restore(core.config['torque.pbs-serverdb'], 'pbs')
+        files.restore(core.config['torque.pbs-nodes-file'], 'pbs')
+
+    def test_02_stop_trqauthd(self):
+        core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_ok_unless(core.state['trqauthd.started-service'], 'did not start trqauthd')
+        service.check_stop('trqauthd')
+        files.restore(core.config['torque.pbs-servername-file'], 'pbs')
+
+    def test_03_stop_scheduler(self):
+        core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_ok_unless(core.state['pbs_sched.started-service'], 'did not start pbs scheduler')
+        service.check_stop('pbs_sched')
+
+    def test_04_stop_mom(self):
+        core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_ok_unless(core.state['pbs_mom.started-service'], 'did not start pbs mom server')
         service.stop('pbs_mom')
 
         for mom_file in ['config', 'layout']:
             files.restore(core.config['torque.mom-%s' % mom_file], 'pbs')
-        core.state['torque.pbs-mom-running'] = False
 
-    def test_02_stop_server(self):
+    def test_05_stop_munge(self):
         core.skip_ok_unless_installed(*self.required_rpms)
-        self.skip_ok_if(core.state['torque.pbs-server-started'] == False, 'did not start pbs server')
-
-        service.check_stop('pbs_server')
-
-        if core.state['trqauthd.started-service']:
-            service.check_stop('trqauthd')
-
-        files.restore(core.config['torque.pbs-servername-file'], 'pbs')
-        files.restore(core.config['torque.pbs-nodes-file'], 'pbs')
-        core.state['torque.pbs-server-running'] = False
-
-    def test_03_stop_scheduler(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
-        self.skip_ok_if(core.state['torque.pbs-sched-running'] == False, 'did not start pbs scheduler')
-
-        service.check_stop('pbs_sched')
-
-        core.state['torque.pbs-sched-running'] = False
-
-    def test_04_stop_munge(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
-        self.skip_ok_if(core.state['munge.running'] == False, 'munge not running')
-
+        self.skip_ok_unless(core.state['munge.started-service'], 'munge not running')
         service.check_stop('munge')
-
-        core.state['munge.running'] = False
         files.restore(core.config['munge.keyfile'], 'pbs')
 


### PR DESCRIPTION
Test results here: http://vdt.cs.wisc.edu/tests/20161129-0935/results.html

The PBS server startup test started being "skipped" when we replaced the `core.system()` call to stop the service with `service.stop()`*, which doesn't start the service unless we set `core.state['pbs_server.started-service'] = True`**. We didn't have a complete PBS blind spot in the tests because the `condor_ce_trace_pbs` jobs seemed to run fine...

\* We stopped the service because we had to run `service pbs create` to create the initial config and it did a bad job of stopping the service afterwards, which we needed to do to drop additional config (maybe?).

** We really shouldn't be setting `core.state` variables in our library functions, at the very least, not the `<service name>.started-service` keys because it makes following service state confusing.

