### PR TITLE
configure tomcat to use "catalina.log" (SOFTWARE-2547)

### DIFF
--- a/osgtest/library/tomcat.py
+++ b/osgtest/library/tomcat.py
@@ -1,5 +1,4 @@
 import os
-from datetime import date
 
 import osgtest.library.core as core
 
@@ -43,7 +42,7 @@ def catalinafile():
     if majorver() <= 6:
         return os.path.join(logdir(), 'catalina.out')
     else:
-        return os.path.join(logdir(), 'catalina.%s.log' % date.strftime(date.today(), '%F'))
+        return os.path.join(logdir(), 'catalina.log')
 
 def pidfile():
     "Path of pid file of a running Tomcat"

--- a/osgtest/tests/test_24_tomcat.py
+++ b/osgtest/tests/test_24_tomcat.py
@@ -85,6 +85,12 @@ class TestStartTomcat(osgunittest.OSGTestCase):
         files.append(core.config['tomcat.logging-conf'], 'org.apache.catalina.level = %s\n' % log_level,
                      owner='tomcat', backup=True)
 
+        old_str  =  "1catalina.org.apache.juli.FileHandler.prefix = catalina."
+        repl_str = ("1catalina.org.apache.juli.FileHandler.prefix = catalina\n"
+                    "1catalina.org.apache.juli.FileHandler.rotatable = false")
+        files.replace(core.config['tomcat.logging-conf'], old_str, repl_str,
+                      owner='tomcat', backup=False)
+
         service.check_start(tomcat.pkgname())
         if core.options.nightly:
             timeout = 3600.0


### PR DESCRIPTION
... instead of "catalina.CYMD.log".

Ran a test run against it, which looks good:
http://vdt.cs.wisc.edu/tests/20161209-1405/packages.html
