### PR TITLE
Handle different alternatives formats

### DIFF
--- a/osgtest/library/java.py
+++ b/osgtest/library/java.py
@@ -26,9 +26,9 @@ def select_ver(java_type, version):
     """Select the specified version of java in the alternatives"""
     alternatives = _run_alternatives(java_type, '\n', 'find %s version for selection' % java_type)
     selection = ''
-    for alt in re.finditer(r'(\d+)\s+(\/.*\n)', alternatives):
-        if version in alt.group(2):
-            selection = alt.group(1)
+    for alt in alternatives.split('\n'):
+        if version in alt:
+            selection = re.match(r'[\s\*\+]*(\d+)\s+', alt).group(1)
     _run_alternatives(java_type, '%s\n' % selection, 'select %s version' % java_type)
 
 def get_ver(java_type):
@@ -41,7 +41,7 @@ def verify_ver(java_type, expected_version):
     command = (java_type, '-version')
     stdout, _, _ = core.check_system(command, 'verify %s version' % java_type)
     try:
-        runtime_version = re.search('(\d+\.\d+\.\d+)', stdout.split('\n')[0]).group(1)
+        runtime_version = re.search(r'(\d+\.\d+\.\d+)', stdout.split('\n')[0]).group(1)
     except AttributeError:
         return False
     return runtime_version in expected_version

--- a/osgtest/tests/test_04_java.py
+++ b/osgtest/tests/test_04_java.py
@@ -1,10 +1,6 @@
-import re
-
 import osgtest.library.yum as yum
 import osgtest.library.core as core
 import osgtest.library.java as java
-import osgtest.library.files as files
-import osgtest.library.tomcat as tomcat
 import osgtest.library.osgunittest as osgunittest
 
 class TestJava(osgunittest.OSGTestCase):

--- a/osgtest/tests/test_97_java.py
+++ b/osgtest/tests/test_97_java.py
@@ -1,7 +1,5 @@
 import osgtest.library.core as core
 import osgtest.library.java as java
-import osgtest.library.files as files
-import osgtest.library.tomcat as tomcat
 import osgtest.library.osgunittest as osgunittest
 
 class TestCleanupJava(osgunittest.OSGTestCase):


### PR DESCRIPTION
Previous formatting of java alternatives:

```
*+ 1           /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.111-2.6.7.2.el7_2.x86_64/jre/bin/java
```

CentOS/RHEL 7 appear to have changed their java alternatives format to the following:

```
*+ 1           java-1.8.0-openjdk.x86_64 (/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.111-2.b15.el7_3.x86_64/jre/bin/java)
   2           java-1.7.0-openjdk.x86_64 (/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.121-2.6.8.0.el7_3.x86_64/jre/bin/java)
```
Here's a run with failing java selection (CentOS and RHEL 7 BeStMan and GUMS tests) : http://vdt.cs.wisc.edu/tests/20161212-1621/results.html
Here's a run with the fix (I excluded 'All*' tests with the hope they'd finish earlier): http://vdt.cs.wisc.edu/tests/20161213-1542/results.html

I also removed the unused libraries from the java tests since I noticed that while I was in there.