### PR TITLE
Test HTCondor-CE + Slurm interaction in automated tests (SOFTWARE-2421)

### DIFF
--- a/files/test_sequence
+++ b/files/test_sequence
@@ -1,6 +1,7 @@
 test_04_java
 test_05_mysqld
 test_06_fetch_crl
+test_07_munge
 test_09_jobs
 test_10_condor
 test_11_condor_cron
@@ -61,6 +62,7 @@ test_89_condor
 test_90_bestman
 test_91_pbs
 test_92_gsiopenssh
+test_94_munge
 test_95_mysqld
 test_96_proxy
 test_97_java

--- a/files/test_sequence
+++ b/files/test_sequence
@@ -22,6 +22,7 @@ test_25_voms_admin
 test_26_bestman
 test_27_osg_info_services
 test_28_gsiopenssh
+test_29_slurm
 test_30_misc
 test_35_osg_configure
 test_38_cvmfs
@@ -44,6 +45,7 @@ test_55_condorce
 test_56_lcgutil
 test_57_osg_info_services
 test_59_gsiopenssh
+test_74_slurm
 test_75_gums
 test_76_tomcat
 test_77_myproxy

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -55,6 +55,11 @@ _log_filename = None
 _last_log_had_output = True
 _el_release = None
 
+SLURM_PACKAGES = ['slurm',
+                  'slurm-munge',
+                  'slurm-perlapi',
+                  'slurm-plugins',
+                  'slurm-sql']
 
 # ------------------------------------------------------------------------------
 # Global Functions

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -1,5 +1,6 @@
 """Support and convenience functions for tests."""
 
+import errno
 import os
 import os.path
 import pwd
@@ -139,6 +140,14 @@ def remove_log():
     """Removes the detailed log file; not for general use."""
     os.remove(_log_filename)
 
+def get_stat(filename):
+    '''Return stat for 'filename', None if the file does not exist'''
+    try:
+        return os.stat(filename)
+    except OSError, exc:
+        if exc.errno == errno.ENOENT:
+            return None
+        raise
 
 def monitor_file(filename, old_stat, sentinel, timeout):
     """Monitors a file for the sentinel regex

--- a/osgtest/library/mysql.py
+++ b/osgtest/library/mysql.py
@@ -32,7 +32,7 @@ def stop():
     service.check_stop(daemon_name())
 
 def is_running():
-    service.is_running(daemon_name())
+    return service.is_running(daemon_name())
 
 def _get_command(user='root', database=None):
     command = ['mysql', '-N', '-B', '--user=' + str(user)]

--- a/osgtest/tests/test_07_munge.py
+++ b/osgtest/tests/test_07_munge.py
@@ -1,0 +1,18 @@
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+
+class TestStartMunge(osgunittest.OSGTestCase):
+
+    def test_01_start_munge(self):
+        core.config['munge.keyfile'] = '/etc/munge/munge.key'
+        core.state['munge.started-service'] = False
+        core.skip_ok_unless_installed('munge')
+        self.skip_ok_if(service.is_running('munge'), 'already running')
+
+        files.preserve(core.config['munge.keyfile'], 'munge')
+        command = ('/usr/sbin/create-munge-key', '-f',)
+        stdout, _, fail = core.check_system(command, 'Create munge key')
+        self.assert_(stdout.find('error') == -1, fail)
+        service.check_start('munge')

--- a/osgtest/tests/test_10_condor.py
+++ b/osgtest/tests/test_10_condor.py
@@ -17,10 +17,7 @@ class TestStartCondor(osgunittest.OSGTestCase):
             core.state['condor.running-service'] = True
             return
 
-        try:
-            core.config['condor.collectorlog_stat'] = os.stat(core.config['condor.collectorlog'])
-        except OSError:
-            core.config['condor.collectorlog_stat'] = None
+        core.config['condor.collectorlog_stat'] = core.get_stat(core.config['condor.collectorlog'])
 
         service.check_start('condor')
         core.state['condor.started-service'] = True

--- a/osgtest/tests/test_17_pbs.py
+++ b/osgtest/tests/test_17_pbs.py
@@ -30,19 +30,7 @@ set server acl_host_enable = True
                      'munge']
 
 
-    def test_01_start_munge(self):
-        core.config['munge.keyfile'] = '/etc/munge/munge.key'
-        core.state['munge.started-service'] = False
-        core.skip_ok_unless_installed(*self.required_rpms)
-        self.skip_ok_if(service.is_running('munge'), 'already running')
-
-        files.preserve(core.config['munge.keyfile'], 'pbs')
-        command = ('/usr/sbin/create-munge-key', '-f',)
-        stdout, _, fail = core.check_system(command, 'Create munge key')
-        self.assert_(stdout.find('error') == -1, fail)
-        service.check_start('munge')
-
-    def test_02_start_mom(self):
+    def test_01_start_mom(self):
         core.state['pbs_mom.started-service'] = False
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(service.is_running('pbs_mom'), 'PBS mom already running')
@@ -57,13 +45,13 @@ set server acl_host_enable = True
                     owner='pbs')
         service.check_start('pbs_mom')
 
-    def test_03_start_pbs_sched(self):
+    def test_02_start_pbs_sched(self):
         core.state['pbs_sched.started-service'] = False
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_ok_if(service.is_running('pbs_sched'), 'PBS sched already running')
         service.check_start('pbs_sched')
 
-    def test_04_start_trqauthd(self):
+    def test_05_start_trqauthd(self):
         core.state['trqauthd.started-service'] = False
         core.config['torque.pbs-servername-file'] = '/var/lib/torque/server_name'
         core.skip_ok_unless_installed(*self.required_rpms)
@@ -75,7 +63,7 @@ set server acl_host_enable = True
                     owner='pbs')
         service.check_start('trqauthd')
 
-    def test_05_configure_pbs(self):
+    def test_04_configure_pbs(self):
         core.config['torque.pbs-nodes-file'] = '/var/lib/torque/server_priv/nodes'
         core.config['torque.pbs-serverdb'] = '/var/lib/torque/server_priv/serverdb'
         core.skip_ok_unless_installed(*self.required_rpms)
@@ -95,7 +83,7 @@ set server acl_host_enable = True
                     "%s np=1 num_node_boards=1\n" % core.get_hostname(),
                     owner='pbs')
 
-    def test_06_start_pbs(self):
+    def test_05_start_pbs(self):
         core.state['pbs_server.started-service'] = False
         core.state['torque.nodes-up'] = False
 

--- a/osgtest/tests/test_17_pbs.py
+++ b/osgtest/tests/test_17_pbs.py
@@ -51,7 +51,7 @@ set server acl_host_enable = True
         self.skip_ok_if(service.is_running('pbs_sched'), 'PBS sched already running')
         service.check_start('pbs_sched')
 
-    def test_05_start_trqauthd(self):
+    def test_03_start_trqauthd(self):
         core.state['trqauthd.started-service'] = False
         core.config['torque.pbs-servername-file'] = '/var/lib/torque/server_name'
         core.skip_ok_unless_installed(*self.required_rpms)
@@ -67,6 +67,7 @@ set server acl_host_enable = True
         core.config['torque.pbs-nodes-file'] = '/var/lib/torque/server_priv/nodes'
         core.config['torque.pbs-serverdb'] = '/var/lib/torque/server_priv/serverdb'
         core.skip_ok_unless_installed(*self.required_rpms)
+        self.skip_bad_unless(service.is_running('trqauthd'), 'pbs_server requires trqauthd')
         self.skip_ok_if(service.is_running('pbs_server'), 'pbs server already running')
 
         files.preserve(core.config['torque.pbs-serverdb'], 'pbs')

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -122,9 +122,7 @@ gridmapfile -> good | bad
             self.skip_ok('already running')
 
         service.check_start('condor-ce')
-        try:
-            stat = os.stat(core.config['condor-ce.collectorlog'])
-        except OSError:
-            stat = None
+
+        stat = core.get_stat(core.config['condor-ce.collectorlog'])
         if condor.wait_for_daemon(core.config['condor-ce.collectorlog'], stat, 'Schedd', 300.0):
             core.state['condor-ce.schedd-ready'] = True

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -43,17 +43,24 @@ class TestStartCondorCE(osgunittest.OSGTestCase):
         core.config['condor-ce.condor-ce-cfg'] = '/etc/condor-ce/config.d/99-osgtest.condor-ce.conf'
         condor_contents = """GRIDMAP = /etc/grid-security/grid-mapfile
 ALL_DEBUG=D_FULLDEBUG
+JOB_ROUTER_DEFAULTS = $(JOB_ROUTER_DEFAULTS) [set_default_maxMemory = 128;]
 JOB_ROUTER_ENTRIES = \\
    [ \\
      GridResource = "batch pbs"; \\
      TargetUniverse = 9; \\
      name = "Local_PBS"; \\
-     Requirements = target.osgTestPBS =?= true; \\
+     Requirements = target.osgTestBatchSystem =?= "pbs"; \\
+   ] \\
+   [ \\
+     GridResource = "batch slurm"; \\
+     TargetUniverse = 9; \\
+     name = "Local_Slurm"; \\
+     Requirements = target.osgTestBatchSystem =?= "slurm"; \\
    ] \\
    [ \\
      TargetUniverse = 5; \\
      name = "Local_Condor"; \\
-     Requirements = target.osgTestPBS =!= true; \\
+     Requirements = (target.osgTestBatchSystem =!= "pbs" && target.osgTestBatchSystem =!= "slurm"); \\
    ]
 
 JOB_ROUTER_SCHEDD2_SPOOL=/var/lib/condor/spool

--- a/osgtest/tests/test_24_tomcat.py
+++ b/osgtest/tests/test_24_tomcat.py
@@ -65,10 +65,7 @@ class TestStartTomcat(osgunittest.OSGTestCase):
         core.state['tomcat.started'] = False
         catalina_log = tomcat.catalinafile()
 
-        try:
-            initial_stat = os.stat(catalina_log)
-        except OSError:
-            initial_stat = None
+        initial_stat = core.get_stat(catalina_log)
 
         if tomcat.majorver() > 5:
             tomcat_sentinel = r'Server startup in \d+ ms'

--- a/osgtest/tests/test_29_slurm.py
+++ b/osgtest/tests/test_29_slurm.py
@@ -92,16 +92,16 @@ class TestStartSlurm(osgunittest.OSGTestCase):
         self.slurm_reqs()
         self.skip_ok_if(service.is_running(core.config['slurm.service-name']), 'slurm already running')
 
-        try:
-            ctld_stat = os.stat(CTLD_LOG)
-        except OSError:
-            ctld_stat = None
+        stat = core.get_stat(CTLD_LOG)
 
         command = ['slurmctld']
         core.check_system(command, 'enable slurmctld')
         service.check_start(core.config['slurm.service-name'])
 
-        core.monitor_file(CTLD_LOG, ctld_stat, 'slurm_rpc_node_registration complete for %s' % SHORT_HOSTNAME, 60.0)
+        core.monitor_file(CTLD_LOG,
+                          stat,
+                          'slurm_rpc_node_registration complete for %s' % SHORT_HOSTNAME,
+                          60.0)
         command = ['scontrol', 'update', 'nodename=%s' % SHORT_HOSTNAME, 'state=idle']
         core.check_system(command, 'enable slurm node')
 

--- a/osgtest/tests/test_29_slurm.py
+++ b/osgtest/tests/test_29_slurm.py
@@ -1,0 +1,107 @@
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.mysql as mysql
+import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+
+CLUSTER_NAME = 'osg_test'
+CTLD_LOG = '/var/log/slurm/slurmctld.log'
+SHORT_HOSTNAME = core.get_hostname().split('.')[0]
+
+SLURMDBD_CONFIG = """AuthType=auth/munge
+DbdHost=localhost
+SlurmUser=slurm
+DebugLevel=debug5
+LogFile=/var/log/slurm/slurmdbd.log
+StorageType=accounting_storage/mysql
+StorageLoc=%(name)s
+StorageUser=%(user)s
+StoragePass=%(pass)s
+"""
+
+SLURM_CONFIG = """AccountingStorageHost=localhost
+AccountingStorageLoc=/tmp/slurm_job_accounting.txt
+AccountingStorageType=accounting_storage/slurmdbd
+AuthType=auth/munge
+ClusterName=%(cluster)s
+ControlMachine=%(short_hostname)s
+JobAcctGatherType=jobacct_gather/linux
+KillWait=30
+NodeName=%(short_hostname)s Procs=1 RealMemory=128 State=UNKNOWN
+PartitionName=debug Nodes=%(short_hostname)s Default=YES MaxTime=INFINITE State=UP
+ReturnToService=2
+SlurmUser=slurm
+SlurmctldDebug=debug5
+SlurmctldTimeout=300
+SlurmctldLogFile=%(ctld_log)s
+SlurmdLogFile=/var/log/slurm/slurm.log
+SlurmdDebug=debug5
+StateSaveLocation=/var/spool/slurmd
+"""
+
+class TestStartSlurm(osgunittest.OSGTestCase):
+
+    def slurm_reqs(self):
+        core.skip_ok_unless_installed(*core.SLURM_PACKAGES)
+        self.skip_bad_unless(service.is_running('munge'), 'slurm requires munge')
+
+    def test_01_slurm_config(self):
+        self.slurm_reqs()
+        core.config['slurm.config'] = '/etc/slurm/slurm.conf'
+        files.write(core.config['slurm.config'],
+                    SLURM_CONFIG % {'short_hostname': SHORT_HOSTNAME, 'cluster': CLUSTER_NAME, 'ctld_log': CTLD_LOG},
+                    owner='slurm',
+                    chmod=0644)
+
+    def test_02_start_slurmdbd(self):
+        core.state['slurmdbd.started-service'] = False
+        self.slurm_reqs()
+        core.skip_ok_unless_installed('slurm-slurmdbd')
+        self.skip_bad_unless(mysql.is_running(), 'slurmdbd requires mysql')
+        core.config['slurmdbd.config'] = '/etc/slurm/slurmdbd.conf'
+        core.config['slurmdbd.user'] = "'osg-test-slurm'@'localhost'"
+        core.config['slurmdbd.name'] = "osg_test_slurmdb"
+
+        mysql.check_execute("create database %s; " % core.config['slurmdbd.name'], 'create slurmdb')
+        mysql.check_execute("create user %s; " % core.config['slurmdbd.user'], 'add slurmdb user')
+        mysql.check_execute("grant usage on *.* to %s; " % core.config['slurmdbd.user'], 'slurmdb user access')
+        mysql.check_execute("grant all privileges on %s.* to %s identified by '%s'; " % (core.config['slurmdbd.name'],
+                                                                                         core.config['slurmdbd.user'],
+                                                                                         core.options.password),
+                            'slurmdb user permissions')
+        mysql.check_execute("flush privileges;", 'reload privileges')
+
+        db_config_vals = {'name':core.config['slurmdbd.name'],
+                          'user':core.config['slurmdbd.user'].split('\'')[1],
+                          'pass':core.options.password}
+        files.write(core.config['slurmdbd.config'],
+                    SLURMDBD_CONFIG % db_config_vals,
+                    owner='slurm',
+                    chmod=0644)
+        service.check_start('slurmdbd')
+
+        # Adding the cluster to the database
+        command = ('sacctmgr', '-i', 'add', 'cluster', CLUSTER_NAME)
+        core.check_system(command, 'add slurm cluster')
+
+    def test_03_start_slurm(self):
+        core.config['slurm.service-name'] = 'slurm'
+        if core.el_release() == 7:
+            core.config['slurm.service-name'] += 'd'
+        core.state['%s.started-service' % core.config['slurm.service-name']] = False
+        self.slurm_reqs()
+        self.skip_ok_if(service.is_running(core.config['slurm.service-name']), 'slurm already running')
+
+        try:
+            ctld_stat = os.stat(CTLD_LOG)
+        except OSError:
+            ctld_stat = None
+
+        command = ['slurmctld']
+        core.check_system(command, 'enable slurmctld')
+        service.check_start(core.config['slurm.service-name'])
+
+        core.monitor_file(CTLD_LOG, ctld_stat, 'slurm_rpc_node_registration complete for %s' % SHORT_HOSTNAME, 60.0)
+        command = ['scontrol', 'update', 'nodename=%s' % SHORT_HOSTNAME, 'state=idle']
+        core.check_system(command, 'enable slurm node')
+

--- a/osgtest/tests/test_54_gratia.py
+++ b/osgtest/tests/test_54_gratia.py
@@ -232,7 +232,7 @@ class TestGratia(osgunittest.OSGTestCase):
         self.skip_ok_unless(core.state['gridftp.started-server'], 'gridftp server not running')
         self.skip_bad_unless(core.state['gratia.gridftp-logs-copied'], 'gridftp logs not copied')
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         if core.package_version_compare('gratia-probe-gridftp-transfer', '1.17.0-1') >= 0:
@@ -289,7 +289,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.state['gratia.glexec_meter-running'] = False
         self.skip_bad_if(core.state['gratia.glexec-logs-copied'] == False)
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         command = ('/usr/share/gratia/glexec/glexec_meter',)
@@ -348,7 +348,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.state['gratia.dcache-storage-running'] = False
         self.skip_bad_if(core.state['gratia.dcache-logs-copied'] == False)
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         command = ('/usr/share/gratia/dCache-storage/dCache-storage_meter.cron.sh',)
@@ -422,7 +422,7 @@ class TestGratia(osgunittest.OSGTestCase):
                              'gatekeeper not running')
         self.skip_bad_unless(core.state['condor.running-service'], message='Condor service not running')
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         command = ('/usr/share/gratia/condor/condor_meter',)
@@ -469,7 +469,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('gratia-probe-bdii-status', 'gratia-service')
         core.state['gratia.bdii-status-running'] = False
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         command = ('/usr/share/gratia/bdii-status/bdii_cese_record',)
@@ -516,7 +516,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.state['gratia.pbs-running'] = False
         self.skip_bad_if(core.state['gratia.pbs-logs-copied'] == False)
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         command = ('/usr/share/gratia/pbs-lsf/pbs-lsf_meter.cron.sh',)
@@ -564,7 +564,7 @@ class TestGratia(osgunittest.OSGTestCase):
         core.state['gratia.sge-running'] = False
         self.skip_bad_if(core.state['gratia.sge-logs-copied'] == False)
         if os.path.exists(core.config['gratia.log.file']):
-            core.state['gratia.log.stat'] = os.stat(core.config['gratia.log.file'])
+            core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
         command = ('/usr/share/gratia/sge/sge_meter.cron.sh',)

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -161,10 +161,8 @@ gums.authz=https://%s:8443/gums/services/GUMSXACMLAuthorizationServicePort
         core.state['condor-ce.gums-auth'] = True
 
         service.check_stop('condor-ce')
-        try:
-            stat = os.stat(core.config['condor-ce.collectorlog'])
-        except OSError:
-            stat = None
+
+        stat = core.get_stat(core.config['condor-ce.collectorlog'])
 
         service.check_start('condor-ce')
         # Wait for the schedd to come back up

--- a/osgtest/tests/test_74_slurm.py
+++ b/osgtest/tests/test_74_slurm.py
@@ -1,0 +1,28 @@
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.mysql as mysql
+import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+
+class TestStopSlurm(osgunittest.OSGTestCase):
+
+    def slurm_reqs(self):
+        core.skip_ok_unless_installed(*core.SLURM_PACKAGES)
+
+    def test_01_stop_slurm(self):
+        self.slurm_reqs()
+        self.skip_ok_unless(core.state['%s.started-service' % core.config['slurm.service-name']], 'did not start slurm')
+        service.check_stop(core.config['slurm.service-name']) # service requires config so we stop it first
+        files.restore(core.config['slurm.config'], 'slurm')
+
+    def test_02_stop_slurmdbd(self):
+        self.slurm_reqs()
+        core.skip_ok_unless_installed('slurm-slurmdbd')
+        self.skip_ok_unless(core.state['slurmdbd.started-service'], 'did not start slurmdbd')
+        # service requires config so we stop it first; use stop() since slurmdbd fails to remove pid file
+        service.stop('slurmdbd')
+        files.restore(core.config['slurmdbd.config'], 'slurm')
+        mysql.check_execute("drop database %s; " % core.config['slurmdbd.name'] + \
+                            "drop user %s;" % core.config['slurmdbd.user'],
+                            'drop mysql slurmdb')
+

--- a/osgtest/tests/test_91_pbs.py
+++ b/osgtest/tests/test_91_pbs.py
@@ -38,10 +38,3 @@ class TestStopPBS(osgunittest.OSGTestCase):
 
         for mom_file in ['config', 'layout']:
             files.restore(core.config['torque.mom-%s' % mom_file], 'pbs')
-
-    def test_05_stop_munge(self):
-        core.skip_ok_unless_installed(*self.required_rpms)
-        self.skip_ok_unless(core.state['munge.started-service'], 'munge not running')
-        service.check_stop('munge')
-        files.restore(core.config['munge.keyfile'], 'pbs')
-

--- a/osgtest/tests/test_94_munge.py
+++ b/osgtest/tests/test_94_munge.py
@@ -1,0 +1,13 @@
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+
+class TestStopMunge(osgunittest.OSGTestCase):
+
+    def test_01_stop_munge(self):
+        core.skip_ok_unless_installed('munge')
+        self.skip_ok_unless(core.state['munge.started-service'], 'munge not running')
+        service.check_stop('munge')
+        files.restore(core.config['munge.keyfile'], 'munge')
+


### PR DESCRIPTION
Test results [here]( http://vdt.cs.wisc.edu/tests/20161214-1435/results.html); failures, although festive, are unrelated.

This set of commits:

* Separates out the munge service setup since it's required by both PBS and SLURM tests
* Installs slurm from osg-contrib if we're running 'All*' tests
* Fixes a mysql.is_running bug and PBS startup bug that I noticed when testing
* Added get_stat() function to handle missing files. This was duplicated throughout the tests before the function.

@osg-cat: I don't think this needs much of a review, assign as you see fit.