### PR TITLE
Limit condor_{ce_,}run tests to 10 minutes

### DIFF
--- a/osgtest/tests/test_41_jobs.py
+++ b/osgtest/tests/test_41_jobs.py
@@ -25,7 +25,10 @@ class TestRunJobs(osgunittest.OSGTestCase):
         os.chdir(tmp_dir)
         os.chmod(tmp_dir, 0777)
 
-        stdout = core.check_system(command, message, user=True)[0]
+        try:
+            stdout = core.check_system(command, message, user=True, timeout=600)[0]
+        except osgunittest.TimeoutException:
+            self.fail("Job failed to complete in 10 minute window")
 
         if verify_environment:
             self.verify_job_environment(stdout)


### PR DESCRIPTION
@edquist: Requesting that you look this over since you wrote the `core.__run_command()` timeout stuff. Should be a short review. 

### Background 

`condor_*run` will patiently wait for jobs to complete even if the job has no chance of completing. Utilize Carl's timeout option to `core.check_system()` to avoid TIMEOUT failures.

### Test Results

Before this commit: http://vdt.cs.wisc.edu/tests/20170109-1206/results.html
After this commit: http://vdt.cs.wisc.edu/tests/20170118-1100/results.html