### PR TITLE
Travis-CI support (SOFTWARE-2313)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: required
+env:
+  matrix:
+  - OS_TYPE=centos OS_VERSION=6 PACKAGE=htcondor-ce-condor
+  - OS_TYPE=centos OS_VERSION=6 PACKAGE=osg-gridftp
+  - OS_TYPE=centos OS_VERSION=6 PACKAGE=osg-gums
+  - OS_TYPE=centos OS_VERSION=7 PACKAGE=htcondor-ce-condor
+  - OS_TYPE=centos OS_VERSION=7 PACKAGE=osg-gridftp
+  - OS_TYPE=centos OS_VERSION=7 PACKAGE=osg-gums
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get update
+  - echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null
+  - sudo service docker restart
+  - sleep 5
+  - sudo docker pull centos:centos${OS_VERSION}
+
+script:
+ # Run tests in Container
+- travis-ci/setup_tests.sh ${OS_VERSION} ${PACKAGE}
+

--- a/travis-ci/setup_tests.sh
+++ b/travis-ci/setup_tests.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -xe
+
+# This script starts docker and systemd (if el7)
+
+# Version of CentOS/RHEL
+el_version=$1
+
+ # Run tests in Container
+if [ "$el_version" = "6" ]; then
+
+sudo docker run --rm=true -v `pwd`:/osg-test:rw centos:centos${OS_VERSION} /bin/bash -c "bash -xe /osg-test/travis-ci/test_inside_docker.sh ${OS_VERSION} ${PACKAGE}"
+
+elif [ "$el_version" = "7" ]; then
+
+docker run --privileged -d -ti -e "container=docker"  -v /sys/fs/cgroup:/sys/fs/cgroup -v `pwd`:/osg-test:rw  centos:centos${OS_VERSION}   /usr/sbin/init
+DOCKER_CONTAINER_ID=$(docker ps | grep centos | awk '{print $1}')
+docker logs $DOCKER_CONTAINER_ID
+docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec "bash -xe /osg-test/travis-ci/test_inside_docker.sh ${OS_VERSION} ${PACKAGE};
+  echo -ne \"------\nEND OSG-TEST TESTS\n\";"
+docker ps -a
+docker stop $DOCKER_CONTAINER_ID
+docker rm -v $DOCKER_CONTAINER_ID
+
+fi
+
+
+

--- a/travis-ci/test_inside_docker.sh
+++ b/travis-ci/test_inside_docker.sh
@@ -1,0 +1,54 @@
+#!/bin/sh -xe
+
+OS_VERSION=$1
+PACKAGE=$2
+
+ls -l /home
+
+# Clean the yum cache
+yum -y clean all
+yum -y clean expire-cache
+
+# First, install all the needed packages.
+rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm
+
+# Broken mirror?
+echo "exclude=mirror.beyondhosting.net" >> /etc/yum/pluginconf.d/fastestmirror.conf
+
+yum -y install yum-plugin-priorities
+rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el${OS_VERSION}-release-latest.rpm
+yum -y install make git openssl
+
+# Source osg-ca-generator repo version
+git clone https://github.com/opensciencegrid/osg-ca-generator.git
+pushd osg-ca-generator
+git rev-parse HEAD
+make install
+popd
+
+# Install osg-test
+pushd osg-test
+make install
+popd
+
+# HTCondor really, really wants a domain name.  Fake one.
+sed /etc/hosts -e "s/`hostname`/`hostname`.unl.edu `hostname`/" > /etc/hosts.new
+/bin/cp -f /etc/hosts.new /etc/hosts
+
+# Bind on the right interface and skip hostname checks.
+mkdir -p /etc/condor{-ce,}/config.d/
+cat << EOF > /etc/condor/config.d/99-local.conf
+NETWORK_INTERFACE=eth0
+GSI_SKIP_HOST_CHECK=true
+SCHEDD_DEBUG=\$(SCHEDD_DEBUG) D_FULLDEBUG
+SCHEDD_INTERVAL=1
+SCHEDD_MIN_INTERVAL=1
+EOF
+cp /etc/condor/config.d/99-local.conf /etc/condor-ce/config.d/99-local.conf
+
+# Reduce the trace timeouts
+export _condor_CONDOR_CE_TRACE_ATTEMPTS=60
+
+# Ok, do actual testing
+echo "------------ OSG Test --------------"
+osg-test -vad --hostcert --no-cleanup --install ${PACKAGE}

--- a/travis-ci/test_inside_docker.sh
+++ b/travis-ci/test_inside_docker.sh
@@ -12,9 +12,6 @@ yum -y clean expire-cache
 # First, install all the needed packages.
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.noarch.rpm
 
-# Broken mirror?
-echo "exclude=mirror.beyondhosting.net" >> /etc/yum/pluginconf.d/fastestmirror.conf
-
 yum -y install yum-plugin-priorities
 rpm -Uvh https://repo.grid.iu.edu/osg/3.3/osg-3.3-el${OS_VERSION}-release-latest.rpm
 yum -y install make git openssl


### PR DESCRIPTION
Since we're limited to 5 concurrent builds and we're kicking so many off, we should make sure that we set the opensciencegrid/osg-test travis-ci limit to 2 builds at a time.