### PR TITLE
Don't depend on htcondor-ce-condor

### DIFF
--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -14,7 +14,8 @@ class TestStartCondorCE(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
 
         core.config['condor-ce.condor-cfg'] = '/etc/condor/config.d/99-osgtest.condor.conf'
-        contents = """SCHEDD_INTERVAL=1"""
+        contents = """SCHEDD_INTERVAL=1
+QUEUE_SUPER_USER_MAY_IMPERSONATE = .*"""
 
         files.write(core.config['condor-ce.condor-cfg'],
                     contents,

--- a/osgtest/tests/test_79_condorce.py
+++ b/osgtest/tests/test_79_condorce.py
@@ -5,12 +5,12 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestStopCondorCE(osgunittest.OSGTestCase):
     def test_01_stop_condorce(self):
-        core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor')
+        core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
         self.skip_ok_unless(core.state['condor-ce.started-service'], 'did not start server')
         service.check_stop('condor-ce')
 
     def test_02_restore_config(self):
-        core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client', 'htcondor-ce-condor')
+        core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
 
         if core.rpm_is_installed('gums-service') and core.state['condor-ce.gums-auth']:
             files.restore(core.config['condor-ce.lcmapsdb'], 'condor-ce.gums')


### PR DESCRIPTION
`htcondor-ce-condor` just provides config for `htcondor-ce` and the `condor` backend. Installing `htcondor-ce` brings all the actual packages necessary for testing CE -> condor job submission; we already throw down half of the necessary config by writing our own job routes, so we just need to add the backend `condor` configuration