### PR TITLE
Drop job env backup cleanup dependence on osg-configure

### DIFF
--- a/osgtest/tests/test_49_jobs.py
+++ b/osgtest/tests/test_49_jobs.py
@@ -11,7 +11,6 @@ class TestCleanupJobs(osgunittest.OSGTestCase):
     """Clean any configuration we touched for running jobs"""
 
     def test_01_restore_job_env(self):
-        core.skip_ok_unless_installed('osg-configure')
         core.skip_ok_unless_one_installed(['htcondor-ce', 'globus-gatekeeper', 'condor'])
 
         files.restore(core.config['osg.job-environment'], owner='pbs')


### PR DESCRIPTION
We already dropped the creation of the job env files in 840ea8

Tests without this commit: http://vdt.cs.wisc.edu/tests/20170417-1748/results.html
Tests with the commit: http://vdt.cs.wisc.edu/tests/20170418-1146/results.html