### PR TITLE
Drop EL5 and 3.1 codepaths

### DIFF
--- a/bootstrap-osg-test
+++ b/bootstrap-osg-test
@@ -44,11 +44,6 @@ esac
 # Determine platform-specific details
 release=`cat /etc/redhat-release`
 case $release in
-    *5.* )
-        rpm_name='epel-release-5-4.noarch.rpm'
-        rpm_path='http://download.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm'
-        osg_name="osg-$version-el5-release-latest.rpm"
-        ;;
     *6.* )
         rpm_name='epel-release-6-8.noarch.rpm'
         rpm_path='http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm'

--- a/osgtest/library/yum.py
+++ b/osgtest/library/yum.py
@@ -31,11 +31,6 @@ def retry_command(command, timeout_seconds=3600):
     deadline = time.time() + timeout_seconds
     fail_msg, status, stdout, stderr = '', '', '', ''
 
-    # EPEL released xrootd-compat (2/17/2015), which requires xrootd >= 4.1,
-    # which is not available in 3.1
-    if core.config['install.original-release-ver'] == '3.1':
-        command.append('--exclude=xrootd-compat*')
-
     # Loop for retries
     while True:
 

--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -49,11 +49,7 @@ class TestInstall(osgunittest.OSGTestCase):
 
             retry_fail, _, stdout, _ = yum.retry_command(command)
             if retry_fail == '':   # the command succeeded
-                if core.el_release() >= 6:
-                    # RHEL 6 does not have the rollback option, so store the
-                    # transaction IDs so we can undo each transaction in the
-                    # proper order
-                    core.state['install.transaction_ids'].append(yum.get_transaction_id())
+                core.state['install.transaction_ids'].append(yum.get_transaction_id())
                 command = ('rpm', '--verify', pkg)
                 core.check_system(command, 'Verify %s' % (pkg))
                 yum.parse_output_for_packages(stdout)
@@ -105,6 +101,4 @@ class TestInstall(osgunittest.OSGTestCase):
         if fail_msg:
             self.fail(fail_msg)
         else:
-            if core.el_release() >= 6:
-                core.state['install.transaction_ids'].append(yum.get_transaction_id())
-
+            core.state['install.transaction_ids'].append(yum.get_transaction_id())

--- a/osgtest/tests/test_12_gatekeeper.py
+++ b/osgtest/tests/test_12_gatekeeper.py
@@ -34,7 +34,6 @@ class TestStartGatekeeper(osgunittest.OSGTestCase):
         # globus-job-run against PBS hangs with the SEG so we disable it and use
         # globus-grid-job-manager-pbs-setup-poll instead
         # https://jira.opensciencegrid.org/browse/SOFTWARE-1929
-        self.skip_ok_if(core.el_release() == 5, 'Disable the SEG for EL5')
         self.skip_ok_if(service.is_running('globus-scheduler-event-generator'), 'SEG already running')
 
         service.check_start('globus-scheduler-event-generator')

--- a/osgtest/tests/test_24_tomcat.py
+++ b/osgtest/tests/test_24_tomcat.py
@@ -34,16 +34,13 @@ class TestStartTomcat(osgunittest.OSGTestCase):
     def test_03_disable_persistence(self):
         core.skip_ok_unless_installed(tomcat.pkgname())
         self.skip_ok_if(core.options.nightly, 'Allow persistence in the nightlies')
-        if core.el_release() > 5:
-            # Disabling persistence doesn't appear to work on EL5
-            # https://tomcat.apache.org/tomcat-5.5-doc/config/manager.html#Disable_Session_Persistence
-            contents='''
+        contents='''
 <Context>
     <WatchedResource>WEB-INF/web.xml</WatchedResource>
     <Manager pathname="" />
 </Context>
 '''
-            files.write(tomcat.contextfile(), contents, owner='tomcat')
+        files.write(tomcat.contextfile(), contents, owner='tomcat')
 
     def test_04_config_tomcat_properties(self):
         if core.missing_rpm(tomcat.pkgname(), 'gratia-service'):

--- a/osgtest/tests/test_30_misc.py
+++ b/osgtest/tests/test_30_misc.py
@@ -64,14 +64,3 @@ class TestMisc(osgunittest.OSGTestCase):
         stdout, _, _ = core.check_system(cmdbase + ['lfc-python.x86_64'], 'lfc-python multilib (64bit)')
         if stdout.strip() == '':
             self.fail('64-bit lfc-python not found in 64-bit repo')
-
-        # Find the 32-bit lfc-python26 rpm (on el5 only)
-        if core.el_release() == 5:
-            stdout, _, _ = core.check_system(cmdbase + ['lfc-python26.i386'], 'lfc-python26 multilib (32bit)')
-            if stdout.strip() == '':
-                self.fail('32-bit lfc-python not found in 64-bit repo')
-
-            # Sanity check: find the 64-bit lfc-python26 rpm
-            stdout, _, _ = core.check_system(cmdbase + ['lfc-python26.x86_64'], 'lfc-python26 multilib (64bit)')
-            if stdout.strip() == '':
-                self.fail('64-bit lfc-python not found in 64-bit repo')

--- a/osgtest/tests/test_76_tomcat.py
+++ b/osgtest/tests/test_76_tomcat.py
@@ -31,8 +31,7 @@ class TestStopTomcat(osgunittest.OSGTestCase):
     def test_05_deconfig_context(self):
         core.skip_ok_unless_installed(tomcat.pkgname())
         self.skip_ok_if(core.options.nightly, 'Allow persistence in the nightlies')
-        if core.el_release() > 5:
-            files.restore(tomcat.contextfile(), 'tomcat')
+        files.restore(tomcat.contextfile(), 'tomcat')
 
     def test_06_remove_trustmanager(self):
         core.skip_ok_unless_installed(tomcat.pkgname(), 'emi-trustmanager-tomcat')


### PR DESCRIPTION
Test results here: http://vdt.cs.wisc.edu/tests/20170531-1316/results.html. osg-gridftp install failures are because I messed up the param file by telling it to install the "osg-gridftp (Java) package". Upgrade failures in 3.4 are due to not having the bestman uninstallation test merged into this branch.

I can kick off a 3.3 osg-gridftp if you want to double check that