### PR TITLE
LCMAPS VOMS plugin tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
 env:
   matrix:
-  - OS_TYPE=centos OS_VERSION=6 PACKAGES=htcondor-ce-condor
-  - OS_TYPE=centos OS_VERSION=6 PACKAGES=osg-gridftp,vo-client-lcmaps-voms,rsv
+  - OS_TYPE=centos OS_VERSION=6 PACKAGES=osg-ce-condor,vo-client-lcmaps-voms,llrun
+  - OS_TYPE=centos OS_VERSION=6 PACKAGES=osg-gridftp,lcmaps,lcmaps-db-templates,vo-client-lcmaps-voms,rsv,llrun
   - OS_TYPE=centos OS_VERSION=6 PACKAGES=osg-gums
-  - OS_TYPE=centos OS_VERSION=7 PACKAGES=htcondor-ce-condor
-  - OS_TYPE=centos OS_VERSION=7 PACKAGES=osg-gridftp,vo-client-lcmaps-voms,rsv
+  - OS_TYPE=centos OS_VERSION=7 PACKAGES=osg-ce-condor,vo-client-lcmaps-voms,llrun
+  - OS_TYPE=centos OS_VERSION=7 PACKAGES=osg-gridftp,lcmaps,lcmaps-db-templates,vo-client-lcmaps-voms,rsv,llrun
   - OS_TYPE=centos OS_VERSION=7 PACKAGES=osg-gums
 
 services:

--- a/osgtest/tests/test_13_gridftp.py
+++ b/osgtest/tests/test_13_gridftp.py
@@ -12,7 +12,7 @@ class TestStartGridFTP(osgunittest.OSGTestCase):
             return
 
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'lcmaps-plugins-voms')
-        core.config['gridftp.env'] = os.path.join('/etc', 'sysconfig', 'globus-gridftp-server')
+        core.config['gridftp.env'] = '/etc/sysconfig/globus-gridftp-server'
         files.append(core.config['gridftp.env'],
                      '''export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
 export LCMAPS_DEBUG_LEVEL=5''',

--- a/osgtest/tests/test_13_gridftp.py
+++ b/osgtest/tests/test_13_gridftp.py
@@ -1,11 +1,24 @@
 import os
 import osgtest.library.core as core
+import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
 
 class TestStartGridFTP(osgunittest.OSGTestCase):
 
-    def test_01_start_gridftp(self):
+
+    def test_01_configure_lcmaps_voms(self):
+        if core.osg_release() < 3.4:
+            return
+
+        core.skip_ok_unless_installed('globus-gridftp-server-progs', 'lcmaps-plugins-voms')
+        core.config['gridftp.env'] = os.path.join('/etc', 'sysconfig', 'globus-gridftp-server')
+        files.append(core.config['gridftp.env'],
+                     '''export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
+export LCMAPS_DEBUG_LEVEL=5''',
+                     owner='gridftp')
+
+    def test_02_start_gridftp(self):
         core.state['gridftp.started-server'] = False
         core.state['gridftp.running-server'] = False
 

--- a/osgtest/tests/test_14_lcmaps.py
+++ b/osgtest/tests/test_14_lcmaps.py
@@ -7,75 +7,16 @@ import unittest
 
 class TestLcMaps(osgunittest.OSGTestCase):
 
-    # ==================================================================
-    def test_01_create_lcmaps_for_glexec(self):
-        core.skip_ok_unless_installed('glexec')
-        path='/etc/lcmaps.db'
-        
-        contents = """
-##############################################################################
-#
-# lcmaps.db
-# 
-# This is a configuration for lcmaps for testing the ce and glexec. It CAN'T
-# be used as-is to test gums.
-# 
-##############################################################################
+    def test_01_configure(self):
+        core.skip_ok_unless_installed('lcmaps', 'lcmaps-db-templates')
 
-glexectracking = "lcmaps_glexec_tracking.mod"
-         "-exec /usr/sbin/glexec_monitor"
-# Uncomment if your procd is located in a non-standard directory
-#         "-procddir /usr"
-# Uncomment to write tracking info to glexec_monitor.log in the given dir
-#     otherwise the default is to use syslog
-#         "-logdir /var/log/glexec"
-# Uncomment to change the default logging level for the glexec_monitor
-#   Level 0: none, 1: errors, 2: warnings, 3: notices, 4: info, 5: debug
-#   The notices level is used for usage tracking; info is commonly useful.
-#   Default is lcmaps_debug_level from glexec.conf.
-#         "-log-level 4"
-# Uncomment to change the syslog facility.  Default is LOG_DAEMON
-#	  "-log-facility LOG_DAEMON"
-# Uncomment to use local time in the file log (doesn't apply to syslog)
-#         "-datetime-local"
-# Uncomment to change the minimum tracking group id
-#         "-min-gid 65000"
-# Uncomment to change the maximum tracking group id
-#         "-max-gid 65049"
-# Uncomment to not kill processes still running after the main process finishes
-#         "-dont-kill-leftovers"
+        core.config['lcmaps.db'] = os.path.join('/etc', 'lcmaps.db')
+        core.config['lcmaps.gsi-authz'] = os.path.join('/etc', 'grid-security', 'gsi-authz.conf')
 
-posix_enf = "lcmaps_posix_enf.mod"
-            "-maxuid 1 -maxpgid 1 -maxsgid 32"
+        template = files.read(os.path.join('/usr', 'share', 'lcmaps', 'templates', 'lcmaps.db.vomsmap'),
+                              as_single_string=True)
 
-gridmapfile = "lcmaps_localaccount.mod"
-              "-gridmap /etc/grid-security/grid-mapfile"
-
-verifyproxy = "lcmaps_verify_proxy.mod"
-          "--allow-limited-proxy"
-          " -certdir /etc/grid-security/certificates"
-
-good        = "lcmaps_dummy_good.mod"
-bad         = "lcmaps_dummy_bad.mod"
-
-# Mapping policies
-
-#
-# Mapping policy: osg_default
-# Purpose:        Used for the Globus gatekeeper and the gridftp server
-#
-osg_default:
-
-gridmapfile -> posix_enf
-
-
-#
-# Mapping policy: glexec
-# Purpose:        Used for glexec on the worker nodes.
-#
-glexec:
-
-verifyproxy -> gridmapfile
-gridmapfile -> glexectracking
-        """
-        files.write(path, contents, owner='lcmaps')
+        files.write(core.config['lcmaps.db'], template, owner='lcmaps')
+        files.write(core.config['lcmaps.gsi-authz'],
+                    "globus_mapping liblcas_lcmaps_gt4_mapping.so lcmaps_callout\n",
+                    owner='lcmaps')

--- a/osgtest/tests/test_14_lcmaps.py
+++ b/osgtest/tests/test_14_lcmaps.py
@@ -8,10 +8,10 @@ import unittest
 class TestLcMaps(osgunittest.OSGTestCase):
 
     def test_01_configure(self):
-        core.skip_ok_unless_installed('lcmaps', 'lcmaps-db-templates')
-
         core.config['lcmaps.db'] = os.path.join('/etc', 'lcmaps.db')
         core.config['lcmaps.gsi-authz'] = os.path.join('/etc', 'grid-security', 'gsi-authz.conf')
+
+        core.skip_ok_unless_installed('lcmaps', 'lcmaps-db-templates')
 
         template = files.read(os.path.join('/usr', 'share', 'lcmaps', 'templates', 'lcmaps.db.vomsmap'),
                               as_single_string=True)

--- a/osgtest/tests/test_14_lcmaps.py
+++ b/osgtest/tests/test_14_lcmaps.py
@@ -8,12 +8,12 @@ import unittest
 class TestLcMaps(osgunittest.OSGTestCase):
 
     def test_01_configure(self):
-        core.config['lcmaps.db'] = os.path.join('/etc', 'lcmaps.db')
-        core.config['lcmaps.gsi-authz'] = os.path.join('/etc', 'grid-security', 'gsi-authz.conf')
+        core.config['lcmaps.db'] = '/etc/lcmaps.db'
+        core.config['lcmaps.gsi-authz'] = '/etc/grid-security/gsi-authz.conf'
 
         core.skip_ok_unless_installed('lcmaps', 'lcmaps-db-templates')
 
-        template = files.read(os.path.join('/usr', 'share', 'lcmaps', 'templates', 'lcmaps.db.vomsmap'),
+        template = files.read('/usr/share/lcmaps/templates/lcmaps.db.vomsmap',
                               as_single_string=True)
 
         files.write(core.config['lcmaps.db'], template, owner='lcmaps')

--- a/osgtest/tests/test_15_xrootd.py
+++ b/osgtest/tests/test_15_xrootd.py
@@ -21,6 +21,25 @@ u xrootd /tmp a
 
 class TestStartXrootd(osgunittest.OSGTestCase):
 
+    def test_01_config_auth(self):
+        if core.osg_release() < 3.4:
+            return
+
+        core.skip_ok_unless_installed('xrootd', 'lcmaps-plugins-voms', 'xrootd-lcmaps', by_dependency=True)
+
+        if core.el_release() > 6:
+            core.config['xrootd.env'] = os.path.join('/etc', 'systemd', 'system', 'xrootd.d', 'osg-test.conf')
+            os.makedirs(os.path.dirname(core.config['xrootd.env']))
+            files.write(core.config['xrootd.env'],
+                        "[Service]\nEnvironment=\"LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1\"",
+                        owner='xrootd')
+        else:
+            core.config['xrootd.env'] = os.path.join('/etc', 'sysconfig', 'xrootd')
+            files.append(core.config['xrootd.env'],
+                         '''export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
+export LCMAPS_DEBUG_LEVEL=5''',
+                         owner='xrootd')
+
     def test_01_start_xrootd(self):
         core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'
         core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'

--- a/osgtest/tests/test_15_xrootd.py
+++ b/osgtest/tests/test_15_xrootd.py
@@ -28,13 +28,13 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('xrootd', 'lcmaps-plugins-voms', 'xrootd-lcmaps', by_dependency=True)
 
         if core.el_release() > 6:
-            core.config['xrootd.env'] = os.path.join('/etc', 'systemd', 'system', 'xrootd.d', 'osg-test.conf')
+            core.config['xrootd.env'] = '/etc/systemd/system/xrootd.d/osg-test.conf'
             os.makedirs(os.path.dirname(core.config['xrootd.env']))
             files.write(core.config['xrootd.env'],
                         "[Service]\nEnvironment=\"LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1\"",
                         owner='xrootd')
         else:
-            core.config['xrootd.env'] = os.path.join('/etc', 'sysconfig', 'xrootd')
+            core.config['xrootd.env'] = '/etc/sysconfig/xrootd'
             files.append(core.config['xrootd.env'],
                          '''export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
 export LCMAPS_DEBUG_LEVEL=5''',

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -37,10 +37,22 @@ QUEUE_SUPER_USER_MAY_IMPERSONATE = .*"""
         core.check_system(command, 'Reconfigure Condor')
         self.assert_(service.is_running('condor'), 'Condor not running after reconfig')
 
-    def test_03_configure_ce(self):
+    def test_03_configure_auth(self):
+        if core.osg_release() < 3.4:
+            return
+
+        core.skip_ok_unless_installed('htcondor-ce', 'lcmaps-plugins-voms')
+        core.config['condorce.env'] = os.path.join('/etc', 'sysconfig', 'condor-ce')
+        files.append(core.config['condorce.env'],
+                     '''export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
+export LCMAPS_DEBUG_LEVEL=5''',
+                     owner='condorce')
+
+    def test_04_configure_ce(self):
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
 
-        # Configure condor-ce to use the gridmap file and set up PBS and Condor routes
+        # Set up Condor, PBS, and Slurm routes
+        # Leave the GRIDMAP knob in tact to verify that it works with the LCMAPS VOMS plugin
         core.config['condor-ce.condor-ce-cfg'] = '/etc/condor-ce/config.d/99-osgtest.condor-ce.conf'
         condor_contents = """GRIDMAP = /etc/grid-security/grid-mapfile
 ALL_DEBUG=D_FULLDEBUG
@@ -78,13 +90,6 @@ JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618
                     owner='condor-ce',
                     chmod=0644)
 
-        # lcmaps needs to know to use the gridmap file instead of GUMS
-        core.config['condor-ce.lcmapsdb'] = '/etc/lcmaps.db'
-        lcmaps_contents = """authorize_only:
-gridmapfile -> good | bad
-"""
-        files.append(core.config['condor-ce.lcmapsdb'], lcmaps_contents, owner='condor-ce')
-
         # Add host DN to condor_mapfile
         if core.options.hostcert:
             core.config['condor-ce.condorce_mapfile'] = '/etc/condor-ce/condor_mapfile'
@@ -97,7 +102,7 @@ gridmapfile -> good | bad
                         owner='condor-ce',
                         chmod=0644)
 
-    def test_04_start_condorce(self):
+    def test_05_start_condorce(self):
         if core.el_release() >= 7:
             core.config['condor-ce.lockfile'] = '/var/lock/condor-ce/htcondor-ceLock'
         else:

--- a/osgtest/tests/test_19_condorce.py
+++ b/osgtest/tests/test_19_condorce.py
@@ -42,7 +42,7 @@ QUEUE_SUPER_USER_MAY_IMPERSONATE = .*"""
             return
 
         core.skip_ok_unless_installed('htcondor-ce', 'lcmaps-plugins-voms')
-        core.config['condorce.env'] = os.path.join('/etc', 'sysconfig', 'condor-ce')
+        core.config['condorce.env'] = '/etc/sysconfig/condor-ce'
         files.append(core.config['condorce.env'],
                      '''export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
 export LCMAPS_DEBUG_LEVEL=5''',

--- a/osgtest/tests/test_44_glexec.py
+++ b/osgtest/tests/test_44_glexec.py
@@ -1,6 +1,7 @@
 import cagen
 import os
 import osgtest.library.core as core
+import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 
 # ==========================================================================
@@ -11,24 +12,44 @@ class TestGlexec(osgunittest.OSGTestCase):
 
     # Constants
     __glexec_client_cert = '/tmp/x509_client_cert'
-    __grid_mapfile = core.config['system.mapfile']   # typically '/etc/grid-security/grid-mapfile'
 
     # attributes to be filled later
     __uid = ''
     __user_proxy_path = ''
-    __good_gridmap = False
 
     # ==========================================================================
 
-    def test_01_check_gridmap(self):
-        core.skip_ok_unless_installed('glexec')
+    def setUpClass(self):
+        # glexec not available in 3.4
+        self.skip_ok_if(core.osg_release())
 
-        key_dn = '"'+ core.config['user.cert_subject'] + '"' + ' ' + core.options.username
 
-        command = ('/bin/grep', key_dn, self.__grid_mapfile)
-        status, _, _ = core.system(command)
-        self.assert_(status == 0, 'Grid-mapfile entry for user '+core.options.username+' missing')
-        TestGlexec.__good_gridmap = True
+    def test_01_configure_lcmaps(self):
+        core.state['glexec.lcmaps_written'] = False
+        core.skip_ok_unless_installed('glexec', 'lcmaps-plugins-basic')
+        # Use the lcmaps.db.gridmap.glexec template from OSG 3.3
+        template = '''glexectracking = "lcmaps_glexec_tracking.mod"
+                 "-exec /usr/sbin/glexec_monitor"
+
+gridmapfile = "lcmaps_localaccount.mod"
+              "-gridmap /etc/grid-security/grid-mapfile"
+
+verifyproxy = "lcmaps_verify_proxy.mod"
+              "--allow-limited-proxy"
+              " -certdir /etc/grid-security/certificates"
+
+good        = "lcmaps_dummy_good.mod"
+bad         = "lcmaps_dummy_bad.mod"
+
+authorize_only:
+gridmapfile -> good | bad
+
+glexec:
+verifyproxy -> gridmapfile
+gridmapfile -> glexectracking
+'''
+        files.write(core.config['lcmaps.db'], template, owner='glexec')
+        core.state['glexec.lcmaps_written'] = True
 
     def test_02_define_user_proxy_path(self):
         core.skip_ok_unless_installed('glexec')
@@ -84,3 +105,8 @@ class TestGlexec(osgunittest.OSGTestCase):
         except:
             pass
 
+
+    def test_06_restore_lcmaps(self):
+        core.skip_ok_unless_installed('glexec', 'lcmaps-plugins-basic')
+        self.skip_ok_unless(core.state['glexec.lcmaps_written'], 'did not write lcmaps.db for glexec tests')
+        files.restore(core.config['lcmaps.db'], 'glexec')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -158,8 +158,8 @@ gums.authz=https://%s:8443/gums/services/GUMSXACMLAuthorizationServicePort
 ''' % (hostname, hostname)
 
         core.config['condor-ce.lcmapsdb'] = os.path.join('/', 'etc', 'lcmaps.db')
-        core.config['condor-ce.gums-properties'] = '/etc/gums/gums-client.properties'
-        core.config['condor-ce.gsi-authz'] = '/etc/grid-security/gsi-authz.conf'
+        core.config['condor-ce.gums-properties'] = os.path.join('/', 'etc', 'gums', 'gums-client.properties')
+        core.config['condor-ce.gsi-authz'] = os.path.join('/', 'etc', 'grid-security', 'gsi-authz.conf')
 
         files.write(core.config['condor-ce.lcmapsdb'], lcmaps_contents, owner='condor-ce.gums')
         files.write(core.config['condor-ce.gums-properties'], gums_properties_contents, owner='condor-ce')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -157,9 +157,9 @@ gumsclient -> good | bad
 gums.authz=https://%s:8443/gums/services/GUMSXACMLAuthorizationServicePort
 ''' % (hostname, hostname)
 
-        core.config['condor-ce.lcmapsdb'] = os.path.join('/', 'etc', 'lcmaps.db')
-        core.config['condor-ce.gums-properties'] = os.path.join('/', 'etc', 'gums', 'gums-client.properties')
-        core.config['condor-ce.gsi-authz'] = os.path.join('/', 'etc', 'grid-security', 'gsi-authz.conf')
+        core.config['condor-ce.lcmapsdb'] = '/etc/lcmaps.db'
+        core.config['condor-ce.gums-properties'] = '/etc/gums/gums-client.properties'
+        core.config['condor-ce.gsi-authz'] = '/etc/grid-security/gsi-authz.conf'
 
         files.write(core.config['condor-ce.lcmapsdb'], lcmaps_contents, owner='condor-ce.gums')
         files.write(core.config['condor-ce.gums-properties'], gums_properties_contents, owner='condor-ce')

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -13,6 +13,13 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestCondorCE(osgunittest.OSGTestCase):
 
+    def setUp(self):
+        # Enforce GSI auth for testing
+        os.environ['_condor_SEC_CLIENT_AUTHENTICATION_METHODS'] = 'GSI'
+
+    def tearDown(self):
+        os.environ.pop('_condor_SEC_CLIENT_AUTHENTICATION_METHODS')
+
     def run_blahp_trace(self, lrms):
         """Run condor_ce_trace() against a non-HTCondor backend and verify the cache"""
         lrms_cache_prefix = {'pbs': 'qstat', 'slurm': 'slurm'}

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -150,6 +150,7 @@ gumsclient -> good | bad
 gums.authz=https://%s:8443/gums/services/GUMSXACMLAuthorizationServicePort
 ''' % (hostname, hostname)
 
+        core.config['condor-ce.lcmapsdb'] = os.path.join('/', 'etc', 'lcmaps.db')
         core.config['condor-ce.gums-properties'] = '/etc/gums/gums-client.properties'
         core.config['condor-ce.gsi-authz'] = '/etc/grid-security/gsi-authz.conf'
 

--- a/osgtest/tests/test_79_condorce.py
+++ b/osgtest/tests/test_79_condorce.py
@@ -18,6 +18,12 @@ class TestStopCondorCE(osgunittest.OSGTestCase):
             files.restore(core.config['condor-ce.gums-properties'], 'condor-ce')
         files.restore(core.config['condor-ce.condor-cfg'], 'condor-ce')
         files.restore(core.config['condor-ce.condor-ce-cfg'], 'condor-ce')
-        files.restore(core.config['condor-ce.lcmapsdb'], 'condor-ce')
         if core.options.hostcert:
             files.restore(core.config['condor-ce.condorce_mapfile'], 'condor-ce')
+
+    def test_03_restore_auth(self):
+        if core.osg_release() < 3.4:
+            return
+
+        core.skip_ok_unless_installed('htcondor-ce', 'lcmaps-plugins-voms')
+        files.restore(core.config['condorce.env'], 'condorce')

--- a/osgtest/tests/test_84_xrootd.py
+++ b/osgtest/tests/test_84_xrootd.py
@@ -15,3 +15,9 @@ class TestStopXrootd(osgunittest.OSGTestCase):
         # TODO: use check_stop after SOFTWARE-2514 is released
         service.stop(core.config['xrootd_service'])
 
+    def test_02_restore_config(self):
+        if core.osg_release() < 3.4:
+            return
+
+        core.skip_ok_unless_installed('xrootd', 'lcmaps-plugins-voms', 'xrootd-lcmaps', by_dependency=True)
+        files.restore(core.config['xrootd.env'], 'xrootd')

--- a/osgtest/tests/test_85_lcmaps.py
+++ b/osgtest/tests/test_85_lcmaps.py
@@ -1,12 +1,11 @@
-import unittest
-
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 
 class TestRestoreLcMaps(osgunittest.OSGTestCase):
 
-    def test_01_restore_lcmaps_after_glexec(self):
-        core.skip_ok_unless_installed('glexec')
+    def test_01_restore_lcmaps(self):
+        core.skip_ok_unless_installed('lcmaps', 'lcmaps-plugins-voms', 'lcmaps-db-templates')
 
-        files.restore('/etc/lcmaps.db', 'lcmaps')
+        files.restore(core.config['lcmaps.gsi-authz'], 'lcmaps')
+        files.restore(core.config['lcmaps.db'], 'lcmaps')

--- a/osgtest/tests/test_86_gridftp.py
+++ b/osgtest/tests/test_86_gridftp.py
@@ -1,5 +1,6 @@
 import os
 import osgtest.library.core as core
+import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
 
@@ -10,3 +11,10 @@ class TestStopGridFTP(osgunittest.OSGTestCase):
         self.skip_ok_if(core.state['gridftp.started-server'] == False, 'did not start server')
         service.check_stop('globus-gridftp-server')
         core.state['gridftp.running-server'] = False
+
+    def test_02_restore_auth(self):
+        if core.osg_release() < 3.4:
+            return
+
+        core.skip_ok_unless_installed('globus-gridftp-server-progs', 'lcmaps-plugins-voms')
+        files.restore(core.config['gridftp.env'], 'gridftp')


### PR DESCRIPTION
This adds testing of the LCMAPS VOMS plugin to the nightlies, replacing the gridmap auth we were testing before. Other things to note:

* The suite still tests `edg-mkgridmap`and `glexec` individually.
* Force GSI auth in HTCondor-CE to ensure that the LCMAPS auth gets exercised. Before it would just fallback to FS auth.
* I'm not sure if XRootd + LCMAPS auth gets exercised (my guess is it doesn't) but added the env variables anyway
