### PR TITLE
Fix SELinux issues with gsi-openssh tests

### DIFF
--- a/osgtest/tests/special_selinux.py
+++ b/osgtest/tests/special_selinux.py
@@ -6,6 +6,7 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestSelinux(osgunittest.OSGTestCase):
     def test_01_selinux(self):
+        core.state['selinux.mode'] = None
         if not core.options.selinux:
             return
 

--- a/osgtest/tests/test_28_gsiopenssh.py
+++ b/osgtest/tests/test_28_gsiopenssh.py
@@ -31,6 +31,12 @@ class TestStartGSIOpenSSH(osgunittest.OSGTestCase):
 
     def test_01_set_config(self):
         port = core.config['gsisshd.port'] = '2222'
+        core.state['gsisshd.can-run'] = (not (
+            core.el_release() >= 7 and
+            core.state['selinux.mode'] and
+            not core.rpm_is_installed('policycoreutils-python')))
+        self.skip_ok_unless(core.state['gsisshd.can-run'],
+                            "Can't run with SELinux on EL >= 7 without policycoreutils-python")
 
         files.write(
             SSHD_CONFIG,
@@ -48,9 +54,5 @@ class TestStartGSIOpenSSH(osgunittest.OSGTestCase):
 
     def test_03_start(self):
         core.state['gsisshd.started-service'] = False
-        core.state['gsisshd.can-run'] = True
-        if core.el_release() >= 7 and core.state['selinux.mode'] and not core.rpm_is_installed(
-                'policycoreutils-python'):
-            core.state['gsisshd.can-run'] = False
-            self.skip_ok("Can't run with SELinux on EL >= 7 without policycoreutils-python")
+        self.skip_ok_unless(core.state['gsisshd.can-run'], "Can't run gsisshd (see above)")
         service.check_start('gsisshd')

--- a/osgtest/tests/test_28_gsiopenssh.py
+++ b/osgtest/tests/test_28_gsiopenssh.py
@@ -6,7 +6,7 @@ from osgtest.library import service
 
 SSHD_CONFIG = "/etc/gsissh/sshd_config"
 SSHD_CONFIG_TEXT = r'''
-Port %(port)d
+Port %(port)s
 AuthorizedKeysFile .ssh/authorized_keys
 UsePrivilegeSeparation sandbox
 
@@ -30,7 +30,7 @@ class TestStartGSIOpenSSH(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
 
     def test_01_set_config(self):
-        port = core.config['gsissh.port'] = 2222
+        port = core.config['gsisshd.port'] = '2222'
 
         files.write(
             SSHD_CONFIG,
@@ -42,9 +42,9 @@ class TestStartGSIOpenSSH(osgunittest.OSGTestCase):
         if not core.state['selinux.mode']:
             self.skip_ok('SELinux disabled')
         core.skip_ok_unless_installed('policycoreutils-python')
-        port = core.config['gsissh.port']
-        core.check_system(['semanage', 'port', '--add', '-t', 'ssh_port_t', '--proto', 'tcp', str(port)],
-                          message="Allow [gsi]sshd to use port %d" % port)
+        port = core.config['gsisshd.port']
+        core.check_system(['semanage', 'port', '--add', '-t', 'ssh_port_t', '--proto', 'tcp', port],
+                          message="Allow [gsi]sshd to use port %s" % port)
 
     def test_03_start(self):
         core.state['gsisshd.started-service'] = False

--- a/osgtest/tests/test_28_gsiopenssh.py
+++ b/osgtest/tests/test_28_gsiopenssh.py
@@ -6,7 +6,7 @@ from osgtest.library import service
 
 SSHD_CONFIG = "/etc/gsissh/sshd_config"
 SSHD_CONFIG_TEXT = r'''
-Port 2222
+Port %(port)d
 AuthorizedKeysFile .ssh/authorized_keys
 UsePrivilegeSeparation sandbox
 
@@ -30,12 +30,21 @@ class TestStartGSIOpenSSH(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
 
     def test_01_set_config(self):
+        port = core.config['gsissh.port'] = 2222
+
         files.write(
             SSHD_CONFIG,
-            SSHD_CONFIG_TEXT,
+            SSHD_CONFIG_TEXT % {'port': port},
             owner='gsissh',
             chmod=0600)
 
-    def test_02_start(self):
+    def test_02_setup_selinux_port(self):
+        if not core.state['selinux.mode']:
+            self.skip_ok('no selinux')
+        port = core.config['gsissh.port']
+        core.check_system(['semanage', 'port', '--add', '-t', 'ssh_port_t', '--proto', 'tcp', str(port)],
+                          message="Allow [gsi]sshd to use port %d" % port)
+
+    def test_03_start(self):
         core.state['gsisshd.started-service'] = False
         service.check_start('gsisshd')

--- a/osgtest/tests/test_59_gsiopenssh.py
+++ b/osgtest/tests/test_59_gsiopenssh.py
@@ -9,7 +9,6 @@ from osgtest.library import osgunittest
 
 
 SOURCE_PATH = '/usr/share/osg-test/test_gridftp_data.txt'
-SSH_PORT = '2222'
 
 
 class TestGSIOpenSSH(osgunittest.OSGTestCase):
@@ -17,12 +16,14 @@ class TestGSIOpenSSH(osgunittest.OSGTestCase):
     temp_dir = None
     remote_path = None
     local_path = None
+    port = None
 
     def setUp(self):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
         self.skip_ok_if(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
         self.skip_ok_unless(core.state['proxy.created'] or core.state['voms.got-proxy'], 'no proxy')
         self.skip_bad_unless(core.state['gsisshd.started-service'], 'gsisshd service not running')
+        self.port = core.config['gsisshd.port']
 
     def test_00_setup(self):
         if not TestGSIOpenSSH.temp_dir or not os.path.isdir(TestGSIOpenSSH.temp_dir):
@@ -33,19 +34,19 @@ class TestGSIOpenSSH(osgunittest.OSGTestCase):
             TestGSIOpenSSH.local_path = TestGSIOpenSSH.temp_dir + '/gsissh_get_copied_file.txt'
 
     def test_01_ssh_to_host(self):
-        command = ['gsissh', '-p', SSH_PORT, self.hostname, 'echo', 'SUCCESS']
+        command = ['gsissh', '-p', self.port, self.hostname, 'echo', 'SUCCESS']
         stdout, _, fail = core.check_system(command, 'SSH to host', user=True, stdin="")
 
         self.assert_('SUCCESS' in stdout, fail)
 
     def test_02_scp_local_to_remote(self):
-        command = ['gsiscp', '-P', SSH_PORT, SOURCE_PATH, self.hostname + ':' + self.remote_path]
+        command = ['gsiscp', '-P', self.port, SOURCE_PATH, self.hostname + ':' + self.remote_path]
         stdout, _, fail = core.check_system(command, 'SCP to host', user=True, stdin="")
 
         self.assert_(os.path.exists(self.remote_path), 'Copied file missing')
 
     def test_03_scp_remote_to_local(self):
-        command = ['gsiscp', '-P', SSH_PORT, self.hostname + ':' + self.remote_path, self.local_path]
+        command = ['gsiscp', '-P', self.port, self.hostname + ':' + self.remote_path, self.local_path]
         stdout, _, fail = core.check_system(command, 'SCP from host', user=True, stdin="")
 
         self.assert_(os.path.exists(self.local_path), 'Copied file missing')

--- a/osgtest/tests/test_59_gsiopenssh.py
+++ b/osgtest/tests/test_59_gsiopenssh.py
@@ -20,6 +20,7 @@ class TestGSIOpenSSH(osgunittest.OSGTestCase):
 
     def setUp(self):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
+        self.skip_ok_if(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
         self.skip_ok_unless(core.state['proxy.created'] or core.state['voms.got-proxy'], 'no proxy')
         self.skip_bad_unless(core.state['gsisshd.started-service'], 'gsisshd service not running')
 

--- a/osgtest/tests/test_59_gsiopenssh.py
+++ b/osgtest/tests/test_59_gsiopenssh.py
@@ -20,7 +20,7 @@ class TestGSIOpenSSH(osgunittest.OSGTestCase):
 
     def setUp(self):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
-        self.skip_ok_if(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
+        self.skip_ok_unless(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
         self.skip_ok_unless(core.state['proxy.created'] or core.state['voms.got-proxy'], 'no proxy')
         self.skip_bad_unless(core.state['gsisshd.started-service'], 'gsisshd service not running')
         self.port = core.config['gsisshd.port']

--- a/osgtest/tests/test_92_gsiopenssh.py
+++ b/osgtest/tests/test_92_gsiopenssh.py
@@ -10,7 +10,7 @@ SSHD_CONFIG = "/etc/gsissh/sshd_config"
 class TestStopGSIOpenSSH(osgunittest.OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
-        self.skip_ok_if(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
+        self.skip_ok_unless(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
 
     def test_01_stop(self):
         service.check_stop('gsisshd')

--- a/osgtest/tests/test_92_gsiopenssh.py
+++ b/osgtest/tests/test_92_gsiopenssh.py
@@ -14,5 +14,12 @@ class TestStopGSIOpenSSH(osgunittest.OSGTestCase):
     def test_01_stop(self):
         service.check_stop('gsisshd')
 
-    def test_02_restore_config(self):
+    def test_02_unset_selinux_port(self):
+        if not core.state['selinux.mode']:
+            self.skip_ok('no selinux')
+        port = core.config['gsissh.port']
+        core.check_system(['semanage', 'port', '--delete', '--proto', 'tcp', str(port)],
+                          message="Forbid [gsi]sshd to use port %d" % port)
+
+    def test_03_restore_config(self):
         files.restore(SSHD_CONFIG, owner='gsissh')

--- a/osgtest/tests/test_92_gsiopenssh.py
+++ b/osgtest/tests/test_92_gsiopenssh.py
@@ -19,9 +19,9 @@ class TestStopGSIOpenSSH(osgunittest.OSGTestCase):
         if not core.state['selinux.mode']:
             self.skip_ok('no selinux')
         core.skip_ok_unless_installed('policycoreutils-python')
-        port = core.config['gsissh.port']
-        core.check_system(['semanage', 'port', '--delete', '--proto', 'tcp', str(port)],
-                          message="Forbid [gsi]sshd to use port %d" % port)
+        port = core.config['gsisshd.port']
+        core.check_system(['semanage', 'port', '--delete', '--proto', 'tcp', port],
+                          message="Forbid [gsi]sshd to use port %s" % port)
 
     def test_03_restore_config(self):
         files.restore(SSHD_CONFIG, owner='gsissh')

--- a/osgtest/tests/test_92_gsiopenssh.py
+++ b/osgtest/tests/test_92_gsiopenssh.py
@@ -10,6 +10,7 @@ SSHD_CONFIG = "/etc/gsissh/sshd_config"
 class TestStopGSIOpenSSH(osgunittest.OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed('gsi-openssh-server', 'gsi-openssh-clients')
+        self.skip_ok_if(core.state['gsisshd.can-run'], "Couldn't run gsisshd (see above)")
 
     def test_01_stop(self):
         service.check_stop('gsisshd')
@@ -17,6 +18,7 @@ class TestStopGSIOpenSSH(osgunittest.OSGTestCase):
     def test_02_unset_selinux_port(self):
         if not core.state['selinux.mode']:
             self.skip_ok('no selinux')
+        core.skip_ok_unless_installed('policycoreutils-python')
         port = core.config['gsissh.port']
         core.check_system(['semanage', 'port', '--delete', '--proto', 'tcp', str(port)],
                           message="Forbid [gsi]sshd to use port %d" % port)


### PR DESCRIPTION
On EL7, SELinux forbids sshd (and gsisshd) from opening unregistered ports (e.g. 2222). This fix allows gsisshd to use port 2222 for the duration of the osg-test run. Some contortions were necessary so that the tests OkSkip if we need policycoreutils-python and can't find it.