### PR TITLE
drop test_052_vo_supported_metric (SOFTWARE-2763)

### DIFF
--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -268,17 +268,6 @@ class TestRSV(osgunittest.OSGTestCase):
         self.run_metric('org.osg.general.osg-version')
         return
 
-    def test_052_vo_supported_metric(self):
-        core.skip_ok_unless_installed('rsv', 'gums-client')
-        core.skip_ok_unless_one_installed('htcondor-ce', 'globus-gatekeeper')
-        # We ok skip if gums-client isn't installed since it's responsible
-        # for creating /var/lib/osg/supported-vo-list in the tests.
-        # edg-mkgridmap is also capable of creating the necessary file but
-        # it places it in a separate location for its tests
-
-        self.run_metric('org.osg.general.vo-supported')
-        return
-
     # Print Java version info, mostly useful for debugging test runs.
     def test_053_java_version_metric(self):
         core.skip_ok_unless_installed('rsv')


### PR DESCRIPTION
the vo-supported-probe is dropped from rsv 3.15.0