### PR TITLE
Grab slurm from development repos instead of contrib (SOFTWARE-2994)

### DIFF
--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -34,7 +34,7 @@ class TestInstall(osgunittest.OSGTestCase):
         # SOFTWARE-1733 gives us a generalized solution
         if 'osg-tested-internal' in pkg_repo_dict:
             all_slurm_packages = core.SLURM_PACKAGES + ['slurm-slurmdbd']
-            pkg_repo_dict.update(dict((x, ['osg-contrib']) for x in all_slurm_packages))
+            pkg_repo_dict.update(dict((x, ['osg-development']) for x in all_slurm_packages))
 
         for pkg, repos in pkg_repo_dict.items():
             # Do not try to re-install packages


### PR DESCRIPTION
Test results are good: http://vdt.cs.wisc.edu/tests/20171117-1442/results.html 