### PR TITLE
Remove options to specify cilogon-type certs (now the default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Fundamentally, the `osg-test` script runs tests and reports on their results. Ho
 | Option                       | Description                                                                                                                                                                                                                                |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `-a`, `--add-user`           | Add and configure the test user account (see also `-u` below). By default, the script assumes that the test user account already exists and is configured with a valid X.509 certificate in its `.globus` directory.                       |
-| `--cilogon`                  | Generate CILogon-like certificates                                                                                                                                                                                                         |
 | `-c`, `--config` FILE        | Configuration file to use that specifies command-line options. See below for syntax                                                                                                                                                        |
 | `-d`, `--dump-output`        | After all test output, print all commands and their output from the test run. Typically generates **a lot** of output.                                                                                                                     |
 | `--df`, `--dump-file` FILE   | Like `--dump-output`, but prints the output to a file instead of the console                                                                                                                                                               |
@@ -85,7 +84,6 @@ Unfortunately, the names of the variables in the config file are not the same as
 | Command-Line         | Config File   | Default Value |
 |:---------------------|:--------------|:--------------|
 | --add-user           | adduser       | False         |
-| --cilogon            | cilogon       | True          |
 | --dump-output        | dumpout       | False         |
 | --dump-file          | dumpfile      | None          |
 | --extra-repo         | extrarepos    | []            |

--- a/osg-test
+++ b/osg-test
@@ -21,7 +21,6 @@ from osgtest.library import osgunittest
 def parse_command_line():
     defaults = {"adduser": False,
                 "backupmysql": False,
-                "cilogon": False,
                 "config": None,
                 "dumpfile": None,
                 "dumpout": False,
@@ -95,9 +94,6 @@ def read_args():
 
     p.add_option('-a', '--add-user', action='store_true', dest='adduser',
                  help='Add and configure the test user account (see -u below)')
-
-    p.add_option('--cilogon', action='store_true', dest='cilogon',
-                 help='Generate CILogon-like certificates')
 
     p.add_option('-c', '--config', action='store', type='string', dest='config',
                  help='Configuration file to use that specifies command-line options')

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -84,7 +84,6 @@ def start_log():
     _log.write('Start time: ' + time.strftime('%Y-%m-%d %H:%M:%S') + '\n\n')
     _log.write('Options:\n')
     _log.write('  - Add user: %s\n' % str(options.adduser))
-    _log.write('  - CILogon-style certs: %s\n' % str(options.cilogon))
     _log.write('  - Config file: %s\n' % options.config)
     _log.write('  - Dump output: %s\n' % str(options.dumpout))
     _log.write('  - Dump file: %s\n' % options.dumpfile)

--- a/osgtest/tests/special_certs.py
+++ b/osgtest/tests/special_certs.py
@@ -9,14 +9,8 @@ class TestCert(osgunittest.OSGTestCase):
         core.state['certs.ca_created'] = False
         core.config['certs.test-ca'] = '/etc/grid-security/certificates/OSG-Test-CA.pem'
         self.skip_ok_if(os.path.exists(core.config['certs.test-ca']), 'OSG TEST CA already exists')
-        if core.options.cilogon:
-            subject_prefix = '/DC=org/DC=opensciencegrid/C=US/'
-            mimic_ca = 'cilogon'
-        else:
-            subject_prefix = '/DC=org/DC=Open Science Grid/'
-            mimic_ca = 'digicert'
-        core.config['certs.ca-subject'] = subject_prefix + 'O=OSG Software/CN=OSG Test CA'
-        CA(core.config['certs.ca-subject'], mimic=mimic_ca)
+        core.config['certs.ca-subject'] = '/DC=org/DC=opensciencegrid/C=US/O=OSG Software/CN=OSG Test CA'
+        CA(core.config['certs.ca-subject'])
         core.state['certs.ca_created'] = True
 
     def test_02_install_host_cert(self):


### PR DESCRIPTION
In conjuction with https://github.com/opensciencegrid/osg-ca-generator/pull/9