### PR TITLE
decorators to tests to osg release series (SOFTWARE-2759)

### DIFF
--- a/osg-test-log-viewer
+++ b/osg-test-log-viewer
@@ -44,7 +44,7 @@ def load_logdata_from_handle(handle):
                                     line)
         match = (re.match(r'message:\s*%s:\s*(.+?)\s*$' % datetime_re, line) or
                  command_match or
-                 re.match(r'((?:FAIL|ERROR|BAD SKIPS|OK SKIPS).+?)\s*$', line) or
+                 re.match(r'((?:FAIL|ERROR|BAD SKIPS|OK SKIPS|EXCLUDED).+?)\s*$', line) or
                  re.match(r'(OSG-TEST LOG)', line))
         output_delimiter = re.match(r'(?:STDOUT|STDERR):[{}]', line)
 

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -715,3 +715,23 @@ def remove_cert(target_key):
         target_dir = state[target_key + '-dir']
         if len(os.listdir(target_dir)) == 0:
             os.rmdir(target_dir)
+
+def osgrelease(*releases):
+    """
+    Return a decorator that will only call its function when the current
+    osg_release version is specified in the list of releases.
+
+        class TestFoo(osgunittest.OSGTestCase):
+
+            @osgrelease(3.4)
+            def test_bar_34_only(self):
+                ...
+    """
+    releases = map(str, releases)  # convert float args to str
+    def osg_release_decorator(fn):
+        def run_fn_if_osg_release_ok(*args, **kwargs):
+            if osg_release() in releases:
+                return fn(*args, **kwargs)
+        return run_fn_if_osg_release_ok
+    return osg_release_decorator
+

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -348,17 +348,8 @@ def skip_ok_unless_installed(*packages_or_dependencies, **kwargs):
     if isinstance(packages_or_dependencies[0], (list, tuple)):
         packages_or_dependencies = packages_or_dependencies[0]
 
-    missing = []
-    if by_dependency:
-        dependencies = packages_or_dependencies
-        for dependency in dependencies:
-            if not dependency_is_installed(dependency):
-                missing.append(dependency)
-    else:
-        packages = packages_or_dependencies
-        for package in packages:
-            if not rpm_is_installed(package):
-                missing.append(package)
+    is_installed = dependency_is_installed if by_dependency else rpm_is_installed
+    missing = [ x for x in packages_or_dependencies if not is_installed(x) ]
 
     if len(missing) > 0:
         raise osgunittest.OkSkipException(message or 'missing %s' % ' '.join(missing))

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -710,7 +710,9 @@ def remove_cert(target_key):
 def osgrelease(*releases):
     """
     Return a decorator that will only call its function when the current
-    osg_release version is specified in the list of releases.
+    osg_release version is specified in the list of releases; otherwise
+    ExcludedException is raised and the test is added to the 'excluded'
+    list.
 
         class TestFoo(osgunittest.OSGTestCase):
 
@@ -723,6 +725,9 @@ def osgrelease(*releases):
         def run_fn_if_osg_release_ok(*args, **kwargs):
             if osg_release() in releases:
                 return fn(*args, **kwargs)
+            else:
+                msg = "excluding for OSG %s" % osg_release()
+                raise osgunittest.ExcludedException(msg)
         return run_fn_if_osg_release_ok
     return osg_release_decorator
 

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -618,14 +618,17 @@ def el_release():
     return _el_release
 
 
-def osg_release():
+def osg_release(update_state=False):
     """
     Return the version of osg-release. If the query fails, the test module fails.
     """
+    if not update_state and 'general.osg_release_ver' in state:
+        return state['general.osg_release_ver']
     try:
         _, _, osg_release_ver, _, _ = get_package_envra('osg-release')
     except OSError:
         _, _, osg_release_ver, _, _ = get_package_envra('osg-release-itb')
+    state['general.osg_release_ver'] = osg_release_ver
     return osg_release_ver
 
 

--- a/osgtest/library/osgunittest.py
+++ b/osgtest/library/osgunittest.py
@@ -268,7 +268,7 @@ class OSGTestResult(unittest.TestResult):
         """
         exctype, value, _ = err
 
-        if exctype in (OkSkipException, BadSkipException, TimeoutException):
+        if exctype in (OkSkipException, ExcludedException, BadSkipException, TimeoutException):
             return str(value)
             # TODO Need some way to print out the line that caused the skip
             # if there is no message.

--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -83,6 +83,7 @@ class TestInstall(osgunittest.OSGTestCase):
             core.options.updaterepos = ['osg']
 
         core.state['install.release-updated'] = True
+        core.osg_release(update_state=True)
 
     def test_04_remove_bestman2_server_dep_libs(self):
         if core.options.updaterelease != "3.4":

--- a/osgtest/tests/test_21_gums.py
+++ b/osgtest/tests/test_21_gums.py
@@ -1,6 +1,6 @@
-import cagen
 import os
 import re
+import cagen
 
 import osgtest.library.core as core
 import osgtest.library.files as files
@@ -14,11 +14,13 @@ class TestStartGUMS(osgunittest.OSGTestCase):
     # ==========================================================================
 
     core.config['gums.password'] = 'osgGUMS!'
-    
+
+    @core.osgrelease(3.3)
     def test_01_config_certs(self):
         core.config['certs.httpcert'] = '/etc/grid-security/http/httpcert.pem'
         core.config['certs.httpkey'] = '/etc/grid-security/http/httpkey.pem'
 
+    @core.osgrelease(3.3)
     def test_02_install_http_certs(self):
         core.skip_ok_unless_installed('gums-service')
         httpcert = core.config['certs.httpcert']
@@ -33,6 +35,7 @@ class TestStartGUMS(osgunittest.OSGTestCase):
     # END: (MOSTLY) COPIED FROM test_20_voms.py
     # ==========================================================================
 
+    @core.osgrelease(3.3)
     def test_03_setup_gums_database(self):
         core.skip_ok_unless_installed('gums-service')
         command = ('gums-setup-mysql-database', '--noprompt', '--user', 'gums', '--host', 'localhost:3306',
@@ -41,6 +44,7 @@ class TestStartGUMS(osgunittest.OSGTestCase):
         self.assert_('ERROR' not in stdout,
                      'gums-setup-mysql-database failure message')
 
+    @core.osgrelease(3.3)
     def test_04_add_mysql_admin(self):
         core.skip_ok_unless_installed('gums-service')
         host_dn, _ = cagen.certificate_info(core.config['certs.hostcert'])
@@ -55,6 +59,7 @@ class TestStartGUMS(osgunittest.OSGTestCase):
         command = ('mysql', '--user=gums', '-p' + core.config['gums.password'], '--execute=' + mysql_command)
         core.check_system(command, 'Could not add GUMS MySQL admin')
 
+    @core.osgrelease(3.3)
     def test_05_gums_configuration(self):
         core.skip_ok_unless_installed('gums-service')
         core.config['gums.config-file'] = '/etc/gums/gums.config'

--- a/osgtest/tests/test_26_bestman.py
+++ b/osgtest/tests/test_26_bestman.py
@@ -4,6 +4,8 @@ import osgtest.library.files as files
 import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
+from osgtest.library.core import osgrelease
+
 class TestStartBestman(osgunittest.OSGTestCase):
 
     def test_01_config_certs(self):
@@ -12,6 +14,7 @@ class TestStartBestman(osgunittest.OSGTestCase):
         core.config['certs.bestmancert'] = '/etc/grid-security/bestman/bestmancert.pem'
         core.config['certs.bestmankey'] = '/etc/grid-security/bestman/bestmankey.pem'
 
+    @osgrelease(3.3)
     def test_02_install_bestman_certs(self):
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')
         if os.path.exists(core.config['certs.bestmancert']) and os.path.exists(core.config['certs.bestmankey']):
@@ -19,6 +22,7 @@ class TestStartBestman(osgunittest.OSGTestCase):
         core.install_cert('certs.bestmancert', 'certs.hostcert', 'bestman', 0644)
         core.install_cert('certs.bestmankey', 'certs.hostkey', 'bestman', 0400)
 
+    @osgrelease(3.3)
     def test_03_modify_sudoers(self):
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')
         sudoers_path = '/etc/sudoers'
@@ -49,6 +53,7 @@ class TestStartBestman(osgunittest.OSGTestCase):
         if not had_srm_cmd_line or not had_requiretty_commented:
             files.write(sudoers_path, new_contents, owner='bestman')
 
+    @osgrelease(3.3)
     def test_04_modify_bestman_conf(self):
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')
 
@@ -72,6 +77,7 @@ class TestStartBestman(osgunittest.OSGTestCase):
         log4j_contents = log4j_contents.replace('FATAL', 'INFO')
         files.write(log4j_path, log4j_contents, backup=False)
 
+    @osgrelease(3.3)
     def test_05_start_bestman(self):
         core.config['bestman.pid-file'] = '/var/run/bestman2.pid'
         core.state['bestman.started-server'] = False

--- a/osgtest/tests/test_51_edgmkgridmap.py
+++ b/osgtest/tests/test_51_edgmkgridmap.py
@@ -1,13 +1,15 @@
-import cagen
 import os
-import osgtest.library.core as core
-import osgtest.library.files as files
-import osgtest.library.osgunittest as osgunittest
 import pwd
 import socket
 
+import cagen
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.osgunittest as osgunittest
+
 class TestEdgMkGridmap(osgunittest.OSGTestCase):
 
+    @core.osgrelease(3.3)
     def test_01_config_mkgridmap(self):
         core.config['edg.conf'] = '/usr/share/osg-test/edg-mkgridmap.conf'
 
@@ -20,6 +22,7 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
         files.write(core.config['edg.conf'], contents, owner='edg')
         core.system(('cat', core.config['edg.conf']))
 
+    @core.osgrelease(3.3)
     def test_02_edg_mkgridmap(self):
         core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
         self.skip_bad_unless(core.state['voms-admin.read-members'], 'Cannot read VO member list')
@@ -45,6 +48,7 @@ class TestEdgMkGridmap(osgunittest.OSGTestCase):
         contents = files.read(os.environ['GRIDMAP'], True)
         self.assert_(expected in contents, 'Expected grid-mapfile contents')
 
+    @core.osgrelease(3.3)
     def test_03_clean_edg_mkgridmap(self):
         core.skip_ok_unless_installed('edg-mkgridmap', 'voms-admin-server')
         self.skip_bad_unless(core.state['voms-admin.read-members'], 'Cannot read VO member list')

--- a/osgtest/tests/test_52_bestman.py
+++ b/osgtest/tests/test_52_bestman.py
@@ -32,12 +32,14 @@ class TestBestman(osgunittest.OSGTestCase):
         TestBestman.__remote_path = TestBestman.__temp_dir + '/bestman_put_copied_file.txt'
         TestBestman.__local_path = TestBestman.__temp_dir + '/bestman_get_copied_file.txt'
 
+    @osgrelease(3.3)
     def test_01_ping(self):
         command = ('srm-ping', self.get_srm_url_base(), '-debug')
         status, stdout, stderr = core.system(command, True)
         fail = core.diagnose('Bestman Ping', command, status, stdout, stderr)
         self.assertEqual(status, 0, fail) 
  
+    @osgrelease(3.3)
     def test_02_copy_local_to_server(self):
         self.setup_temp_paths()
         os.chmod(TestBestman.__temp_dir, 0777)
@@ -48,6 +50,7 @@ class TestBestman(osgunittest.OSGTestCase):
         self.assertEqual(status, 0, fail)
         self.assert_(file_copied, 'Copied file missing')
 
+    @osgrelease(3.3)
     def test_03_copy_server_to_local(self):
         command = ('srm-copy', self.get_srm_url(), 'file://' + TestBestman.__local_path, '-debug')
         status, stdout, stderr = core.system(command, True)
@@ -57,6 +60,7 @@ class TestBestman(osgunittest.OSGTestCase):
         self.assert_(file_copied, 'Copied file missing')
         files.remove(TestBestman.__local_path)
 
+    @osgrelease(3.3)
     def test_04_remove_server_file(self):
         command = ('srm-rm', self.get_srm_url(), '-debug')
         status, stdout, stderr = core.system(command, True)

--- a/osgtest/tests/test_52_bestman.py
+++ b/osgtest/tests/test_52_bestman.py
@@ -5,6 +5,8 @@ import osgtest.library.osgunittest as osgunittest
 import socket
 import tempfile
 
+from osgtest.library.core import osgrelease
+
 class TestBestman(osgunittest.OSGTestCase):
 
     __data_path = '/usr/share/osg-test/test_gridftp_data.txt'
@@ -13,6 +15,7 @@ class TestBestman(osgunittest.OSGTestCase):
     __hostname = socket.getfqdn()
 
 
+    @osgrelease(3.3)
     def setUp(self):
         self.skip_ok_unless(core.state['proxy.created'] or core.state['voms.got-proxy'])
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')

--- a/osgtest/tests/test_53_gums.py
+++ b/osgtest/tests/test_53_gums.py
@@ -8,6 +8,8 @@ class TestGUMS(osgunittest.OSGTestCase):
     required_rpms = ['gums-service',
                      'gums-client']
 
+
+    @core.osgrelease(3.3)
     def test_01_set_x509_env(self):
         core.skip_ok_unless_installed(*self.required_rpms)
 
@@ -26,6 +28,7 @@ class TestGUMS(osgunittest.OSGTestCase):
         os.putenv('X509_USER_CERT', '/etc/grid-security/hostcert.pem')
         os.putenv('X509_USER_KEY', '/etc/grid-security/hostkey.pem')
 
+    @core.osgrelease(3.3)
     def test_02_server_version(self):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_bad_unless(core.state['tomcat.started'], 'Tomcat not started')
@@ -33,6 +36,7 @@ class TestGUMS(osgunittest.OSGTestCase):
         stdout = core.check_system(('gums-host', 'serverVersion'), 'Query GUMS server version')[0]
         self.assert_("GUMS server version" in stdout, "expected string missing from serverVersion output")
 
+    @core.osgrelease(3.3)
     def test_03_manual_group_add(self):
         core.skip_ok_unless_installed(*self.required_rpms)
         core.state['gums.added_user'] = False
@@ -48,6 +52,7 @@ class TestGUMS(osgunittest.OSGTestCase):
         core.check_system(command, 'Add VDT DN to manual group')
         core.state['gums.added_user'] = True
 
+    @core.osgrelease(3.3)
     def test_04_map_user(self):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_bad_unless(core.state['gums.added_user'] == True, 'User not added to manual user group')
@@ -63,6 +68,7 @@ class TestGUMS(osgunittest.OSGTestCase):
         stdout = core.check_system(command, 'Map GUMS user')[0]
         self.assert_(core.options.username in stdout, 'expected string missing from mapUser output')
 
+    @core.osgrelease(3.3)
     def test_05_generate_mapfile(self):
         core.skip_ok_unless_installed(*self.required_rpms)
         self.skip_bad_unless(core.state['gums.added_user'] == True, 'User not added to manual user group')
@@ -74,6 +80,7 @@ class TestGUMS(osgunittest.OSGTestCase):
         stdout = core.check_system(command, 'generate grid mapfile')[0]
         self.assert_(core.config['user.cert_subject'] in stdout, 'user DN missing from generated mapfile')
 
+    @core.osgrelease(3.3)
     def test_06_unset_x509_env(self):
         core.skip_ok_unless_installed(*self.required_rpms)
 

--- a/osgtest/tests/test_75_gums.py
+++ b/osgtest/tests/test_75_gums.py
@@ -4,6 +4,7 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestStopGUMS(osgunittest.OSGTestCase):
 
+    @core.osgrelease(3.3)
     def test_01_restore_files(self):
         core.skip_ok_unless_installed('gums-service')
         files.restore(core.config['gums.config-file'], 'gums')

--- a/osgtest/tests/test_90_bestman.py
+++ b/osgtest/tests/test_90_bestman.py
@@ -3,13 +3,17 @@ import osgtest.library.files as files
 import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
+from osgtest.library.core import osgrelease
+
 class TestStopBestman(osgunittest.OSGTestCase):
 
+    @osgrelease(3.3)
     def test_01_stop_bestman(self):
         core.skip_ok_unless_installed('bestman2-server', 'bestman2-client')
         self.skip_ok_unless(core.state['bestman.started-server'], 'bestman server not started')
         service.check_stop('bestman2')
 
+    @osgrelease(3.3)
     def test_02_deconfig_sudoers(self):
         if core.missing_rpm('bestman2-server', 'bestman2-client'):
             return


### PR DESCRIPTION
this allows test classes to add decorators like:
```
    @osgrelease(3.3)
    def test_foo_33_only(self):
        ...
```
or
```
    @osgrelease(3.3, 3.4)
    def test_foo_33_or_34(self):
        ...
```
to restrict running a particular test function to when the currently installed osg release series is in the provided list.

`@osgrelease(3.3)` is added for the bestman tests, as an example, but the other `skip_ok_unless_installed()`'s still need to be reviewed for 3.3-only packages.