### PR TITLE
osg-test changes for SOFTWARE-3202

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -57,10 +57,10 @@ _last_log_had_output = True
 _el_release = None
 
 SLURM_PACKAGES = ['slurm',
-                  'slurm-munge',
+                  'slurm-slurmd',
+                  'slurm-slurmctld',
                   'slurm-perlapi',
-                  'slurm-plugins',
-                  'slurm-sql']
+                  'slurm-slurmdbd']
 
 # ------------------------------------------------------------------------------
 # Global Functions

--- a/osgtest/tests/test_29_slurm.py
+++ b/osgtest/tests/test_29_slurm.py
@@ -74,7 +74,7 @@ class TestStartSlurm(osgunittest.OSGTestCase):
         if core.el_release() == 6:
             config += "\nCgroupMountpoint=/cgroup"
         files.write(core.config['cgroup.config'],
-                    SLURM_CGROUPS_CONFIG,
+                    config,
                     owner='slurm',
                     chmod=0644)
 

--- a/osgtest/tests/test_29_slurm.py
+++ b/osgtest/tests/test_29_slurm.py
@@ -8,6 +8,7 @@ import time
 
 CLUSTER_NAME = 'osg_test'
 CTLD_LOG = '/var/log/slurm/slurmctld.log'
+SLURM_LOG = '/var/log/slurm/slurm.log'
 SHORT_HOSTNAME = core.get_hostname().split('.')[0]
 
 SLURMDBD_CONFIG = """AuthType=auth/munge
@@ -139,7 +140,11 @@ class TestStartSlurm(osgunittest.OSGTestCase):
                           stat,
                           'slurm_rpc_node_registration complete for %s' % SHORT_HOSTNAME,
                           60.0)
-        time.sleep(10)
+        log_stat = core.get_stat(SLURM_LOG)
+        core.monitor_file(SLURM_LOG,
+                          log_stat,
+                          'slurmd started',
+                          60.0)
         command = ['scontrol', 'update', 'nodename=%s' % SHORT_HOSTNAME, 'state=idle']
         core.check_system(command, 'enable slurm node')
 

--- a/osgtest/tests/test_74_slurm.py
+++ b/osgtest/tests/test_74_slurm.py
@@ -13,6 +13,8 @@ class TestStopSlurm(osgunittest.OSGTestCase):
         self.slurm_reqs()
         self.skip_ok_unless(core.state['%s.started-service' % core.config['slurm.service-name']], 'did not start slurm')
         service.check_stop(core.config['slurm.service-name']) # service requires config so we stop it first
+        if core.el_release() == 7:
+            service.check_stop(core.config['slurm.ctld-service-name'])
         files.restore(core.config['slurm.config'], 'slurm')
 
     def test_02_stop_slurmdbd(self):

--- a/osgtest/tests/test_74_slurm.py
+++ b/osgtest/tests/test_74_slurm.py
@@ -16,6 +16,8 @@ class TestStopSlurm(osgunittest.OSGTestCase):
         if core.el_release() == 7:
             service.check_stop(core.config['slurm.ctld-service-name'])
         files.restore(core.config['slurm.config'], 'slurm')
+        files.restore(core.config['cgroup.config'], 'slurm')
+        files.restore(core.config['cgroup_allowed_devices_file.conf'], 'slurm')
 
     def test_02_stop_slurmdbd(self):
         self.slurm_reqs()


### PR DESCRIPTION
osg-test test changes in order to use slurm 17.  Last VMU results: 
http://vdt.cs.wisc.edu/tests/20180716-1750/results.html