### PR TITLE
Fix htcondor-ce test_06 skip

### DIFF
--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -33,8 +33,7 @@ class TestInstall(osgunittest.OSGTestCase):
         # FIXME: Install slurm out of contrib if we're running 'All' tests until
         # SOFTWARE-1733 gives us a generalized solution
         if 'osg-tested-internal' in pkg_repo_dict:
-            all_slurm_packages = core.SLURM_PACKAGES + ['slurm-slurmdbd']
-            pkg_repo_dict.update(dict((x, ['osg-development']) for x in all_slurm_packages))
+            pkg_repo_dict.update(dict((x, ['osg-development']) for x in core.SLURM_PACKAGES))
 
         for pkg, repos in pkg_repo_dict.items():
             # Do not try to re-install packages

--- a/osgtest/tests/test_55_condorce.py
+++ b/osgtest/tests/test_55_condorce.py
@@ -110,11 +110,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
 
     def test_06_slurm_trace(self):
         self.general_requirements()
-        core.skip_ok_unless_installed('slurm',
-                                      'slurm-munge',
-                                      'slurm-perlapi',
-                                      'slurm-plugins',
-                                      'slurm-sql')
+        core.skip_ok_unless_installed(core.SLURM_PACKAGES)
         self.skip_bad_unless(service.is_running('munge'), 'slurm requires munge')
         self.skip_bad_unless(core.state['condor-ce.schedd-ready'], 'CE schedd not ready to accept jobs')
         self.skip_ok_unless(service.is_running(core.config['slurm.service-name']), 'slurm service not running')


### PR DESCRIPTION
Green on test results and test_06_slurm_trace runs with an ok instead of skipping

http://vdt.cs.wisc.edu/tests/20180727-1122/results.html