### PR TITLE
Ca probes sw 3322 - allow warning status

### DIFF
--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -37,11 +37,15 @@ class TestRSV(osgunittest.OSGTestCase):
         core.check_system(('osg-configure', '-c', '-m', 'rsv'), 'osg-configure -c -m rsv')
         self.start_rsv()
 
-    def run_metric(self, metric, host=host):
+    def run_metric(self, metric, host=host, accept_status=['OK']):
         command = ('rsv-control', '--run', '--host', host, metric)
         stdout = core.check_system(command, ' '.join(command))[0]
 
-        self.assert_(re.search('metricStatus: OK', stdout) is not None)
+        metric_passed = False
+        for status in accept_status:
+            if re.search("metricStatus: %s".format(status), stdout) is not None:
+                metric_passed = True
+        self.assert_(metric_passed)
 
     def load_config_file(self):
         """ Load /etc/rsv/rsv.conf """
@@ -202,12 +206,14 @@ class TestRSV(osgunittest.OSGTestCase):
     def test_032_cacert_expiry(self):
         core.skip_ok_unless_installed('rsv')
 
-        self.run_metric('org.osg.certificates.cacert-expiry')
+        self.run_metric('org.osg.certificates.cacert-expiry',
+                        accept_status=['OK', 'WARNING'])
 
     def test_033_crlcert_expiry(self):
         core.skip_ok_unless_installed('rsv')
 
-        self.run_metric('org.osg.certificates.crl-expiry')
+        self.run_metric('org.osg.certificates.crl-expiry',
+                        accept_status=['OK', 'WARNING'])
 
 
     # Print Java version info, mostly useful for debugging test runs.

--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -204,7 +204,7 @@ class TestRSV(osgunittest.OSGTestCase):
         self.run_metric('org.osg.local.hostcert-expiry')
 
     # OSG 3.3 tries to download from IU and causes a failure
-    @osgrelease(3.4)
+    @core.osgrelease(3.4)
     def test_032_cacert_expiry(self):
         core.skip_ok_unless_installed('rsv', 'htcondor-ce')
 
@@ -212,7 +212,7 @@ class TestRSV(osgunittest.OSGTestCase):
                         accept_status=['OK', 'WARNING'])
 
     # OSG 3.3 tries to download from IU and causes a failure
-    @osgrelease(3.4)
+    @core.osgrelease(3.4)
     def test_033_crlcert_expiry(self):
         core.skip_ok_unless_installed('rsv', 'htcondor-ce')
 

--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -204,13 +204,13 @@ class TestRSV(osgunittest.OSGTestCase):
         self.run_metric('org.osg.local.hostcert-expiry')
 
     def test_032_cacert_expiry(self):
-        core.skip_ok_unless_installed('rsv')
+        core.skip_ok_unless_installed('rsv', 'htcondor-ce')
 
         self.run_metric('org.osg.certificates.cacert-expiry',
                         accept_status=['OK', 'WARNING'])
 
     def test_033_crlcert_expiry(self):
-        core.skip_ok_unless_installed('rsv')
+        core.skip_ok_unless_installed('rsv', 'htcondor-ce')
 
         self.run_metric('org.osg.certificates.crl-expiry',
                         accept_status=['OK', 'WARNING'])

--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -43,7 +43,7 @@ class TestRSV(osgunittest.OSGTestCase):
 
         metric_passed = False
         for status in accept_status:
-            if re.search("metricStatus: %s".format(status), stdout) is not None:
+            if re.search("metricStatus: {0}".format(status), stdout) is not None:
                 metric_passed = True
         self.assert_(metric_passed)
 

--- a/osgtest/tests/test_47_rsv.py
+++ b/osgtest/tests/test_47_rsv.py
@@ -203,12 +203,16 @@ class TestRSV(osgunittest.OSGTestCase):
 
         self.run_metric('org.osg.local.hostcert-expiry')
 
+    # OSG 3.3 tries to download from IU and causes a failure
+    @osgrelease(3.4)
     def test_032_cacert_expiry(self):
         core.skip_ok_unless_installed('rsv', 'htcondor-ce')
 
         self.run_metric('org.osg.certificates.cacert-expiry',
                         accept_status=['OK', 'WARNING'])
 
+    # OSG 3.3 tries to download from IU and causes a failure
+    @osgrelease(3.4)
     def test_033_crlcert_expiry(self):
         core.skip_ok_unless_installed('rsv', 'htcondor-ce')
 


### PR DESCRIPTION
Changes to allow test to pass if metric returns a warning, VMU is green. 

http://vdt.cs.wisc.edu/tests/20180730-2008/results.html 

Also, added a sleep in the test run on fermicloud and deleted crl files to force the metric to give a warning and the test still passed.