### PR TITLE
set xrootd-lcmaps policy in sec_protocol (SOFTWARE-3396)

### DIFF
--- a/osgtest/tests/test_14_lcmaps.py
+++ b/osgtest/tests/test_14_lcmaps.py
@@ -20,16 +20,3 @@ class TestLcMaps(osgunittest.OSGTestCase):
                     "globus_mapping liblcas_lcmaps_gt4_mapping.so lcmaps_callout\n",
                     owner='lcmaps')
 
-    def test_02_xrootd_policy(self):
-        core.skip_ok_unless_installed('xrootd-lcmaps', *self.required_rpms)
-
-        files.append(core.config['lcmaps.db'],
-                     '''xrootd_policy:
-verifyproxynokey -> banfile
-banfile -> banvomsfile | bad
-banvomsfile -> gridmapfile | bad
-gridmapfile -> good | vomsmapfile
-vomsmapfile -> good | defaultmapfile
-defaultmapfile -> good | bad
-''',
-                     backup=False)

--- a/osgtest/tests/test_15_xrootd.py
+++ b/osgtest/tests/test_15_xrootd.py
@@ -48,7 +48,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             lcmaps_packages = ('lcmaps', 'lcmaps-db-templates', 'xrootd-lcmaps', 'vo-client', 'vo-client-lcmaps-voms')
             if all([core.rpm_is_installed(x) for x in lcmaps_packages]):
                 core.log_message("Using xrootd-lcmaps authentication")
-                sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,5'
+                sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,5,--policy,authorize_only'
             else:
                 core.log_message("Using XRootD mapfile authentication")
                 sec_protocol = '-gridmap:/etc/grid-security/xrd/xrdmapfile'


### PR DESCRIPTION
rather than adding an xrootd_policy section to lcmaps.db

This would break due to an argument parsing bug in xrootd-lcmaps < 1.4.0