### PR TITLE
Fix direction of version comparison (SOFTWARE-3396)

### DIFF
--- a/osgtest/tests/test_14_lcmaps.py
+++ b/osgtest/tests/test_14_lcmaps.py
@@ -20,9 +20,9 @@ class TestLcMaps(osgunittest.OSGTestCase):
                     "globus_mapping liblcas_lcmaps_gt4_mapping.so lcmaps_callout\n",
                     owner='lcmaps')
 
-    def test_02_xrootd_policy(self):
+    def test_02_old_xrootd_policy(self):
         core.skip_ok_unless_installed('xrootd-lcmaps', *self.required_rpms)
-        self.skip_ok_unless(core.package_version_compare('xrootd-lcmaps', '1.4.0') >= 0)
+        self.skip_ok_if(core.package_version_compare('xrootd-lcmaps', '1.4.0') >= 0)
 
         files.append(core.config['lcmaps.db'],
                      '''xrootd_policy:


### PR DESCRIPTION
We only want to add this xrootd_policy section to lcmaps.db for
xrootd-lcmaps < 1.4.0, that is, skip if xrootd-lcmaps >= 1.4.0

Also, per Mat's suggestion, i am renaming the name of the test to
say that it is for the "old" xrootd_policy

...

Soon we'll add a more clear helper to do package version checks.