### PR TITLE
Add LWP error to fetch-crl whitelist (cause of EL7 errors)

### DIFF
--- a/osgtest/tests/test_06_fetch_crl.py
+++ b/osgtest/tests/test_06_fetch_crl.py
@@ -23,7 +23,9 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         # ERROR verify called on empty data blob
         'verify called on empty data blob',
         # VERBOSE(0) SDG-G2/0: CRL signature failed
-        'CRL signature failed'
+        'CRL signature failed',
+        # LWP::Protocol::http::Socket: connect: No route to host at /usr/share/perl5/LWP/Protocol/http.pm line 51.
+        'LWP::Protocol::http::Socket',
     ]
 
     def output_is_acceptable(self, fetch_crl_output):


### PR DESCRIPTION
Example: http://vdt.cs.wisc.edu/tests/20181022-0423/126/osg-test-20181022.log