### PR TITLE
Catch OSError in core.check_file_and_perms()

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -647,7 +647,7 @@ def check_file_ownership(file_path, owner_name):
         file_stat = os.stat(file_path)
         return (file_stat.st_uid == owner_uid.pw_uid and
                 stat.S_ISREG(file_stat.st_mode))
-    except OSError:  # file does not exist                                                                                                                                                          
+    except OSError:  # file does not exist
         return False
 
 def check_file_and_perms(file_path, owner_name, permissions):
@@ -656,7 +656,7 @@ def check_file_and_perms(file_path, owner_name, permissions):
     """
     file_stat = os.stat(file_path)
     return (check_file_ownership(file_path, owner_name) and 
-               file_stat.st_mode & 0o7777 == permissions)
+            file_stat.st_mode & 0o7777 == permissions)
 
 def parse_env_output(output):
     """

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -654,9 +654,12 @@ def check_file_and_perms(file_path, owner_name, permissions):
     """Return True if the file at 'file_path' exists, is owned by
     'owner_name', is a file, and has the given permissions; False otherwise
     """
-    file_stat = os.stat(file_path)
-    return (check_file_ownership(file_path, owner_name) and 
-            file_stat.st_mode & 0o7777 == permissions)
+    try:
+        file_stat = os.stat(file_path)
+        return (check_file_ownership(file_path, owner_name) and
+                file_stat.st_mode & 0o7777 == permissions)
+    except OSError:  # file does not exist
+        return False
 
 def parse_env_output(output):
     """


### PR DESCRIPTION
This should fix test failures like in http://vdt.cs.wisc.edu/tests/20181214-0423/098/osg-test-20181214.log