### PR TITLE
PackageVersion comparison helper class

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -449,47 +449,6 @@ def get_package_envra(package_name):
     return (epoch, name, version, release, arch)
 
 
-def version_compare(evr1, evr2):
-    """Compare the EVRs (epoch, version, release) of two RPMs and return
-    - -1 if the first EVR is older than the second,
-    -  0 if the two arguments are equal,
-    -  1 if the first EVR is newer than the second.
-
-    Each EVR may be specified as a string (of the form "V-R" or "E:V-R"), or
-    as a 3-element tuple or list.
-
-    """
-    if is_string(evr1):
-        epoch1, version1, release1 = stringToVersion(evr1)
-    elif isinstance(evr1, bytes):
-        epoch1, version1, release1 = stringToVersion(evr1.decode())
-    else:
-        epoch1, version1, release1 = evr1
-
-    if is_string(evr2):
-        epoch2, version2, release2 = stringToVersion(evr2)
-    elif isinstance(evr2, bytes):
-        epoch2, version2, release2 = stringToVersion(evr2.decode())
-    else:
-        epoch2, version2, release2 = evr2
-
-    return rpm.labelCompare((epoch1, version1, release1), (epoch2, version2, release2))
-
-def package_version_compare(package_name, evr):
-    """Compare EVR of installed package_name to provided evr and return:
-      -1 if the package version is older than evr,
-       0 if the package version is equal to evr,
-       1 if the package version is newer than evr.
-
-    evr can be a string ("[E:]V[-R]") or 3-element tuple or list.
-
-    This is a wrapper around 'version_compare' that avoids having to call
-    'get_package_envra' and extract (e,v,r)
-    """
-    e,n,v,r,a = get_package_envra(package_name)
-    return version_compare((e,v,r), evr)
-
-
 def diagnose(message, command, status, stdout, stderr):
     """Constructs a detailed failure message based on arguments."""
     result = message + '\n'

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -63,6 +63,49 @@ SLURM_PACKAGES = ['slurm',
                   'slurm-perlapi',
                   'slurm-slurmdbd']
 
+
+# ------------------------------------------------------------------------------
+# Helper Classes
+# ------------------------------------------------------------------------------
+
+class PackageVersion:
+    """Compare the installed rpm version of a package to an "[E:]V[-R]" string.
+
+       If the Release field is not specified for [E:]V[-R], it will be ignored
+       for the package's evr in the comparison.  The default Epoch is "0".
+
+       Example package version tests:
+
+            PackageVersion('osg-release')   == '3.4'
+            PackageVersion('xrootd-lcmaps') >= '1.4.0'
+            PackageVersion('voms-server')   <  '2.0.12-3.2'
+
+       Version ranges can also be tested in the normal python fashion:
+
+            '8.4.0' <= PackageVersion('condor') < '8.8.0'
+    """
+
+    def __init__(self, pkgname):
+        e,n,v,r,a = get_package_envra(pkgname)
+        self.evr = e,v,r
+
+    def __repr__(self):
+        return "%s:%s-%s" % self.evr
+
+    def __cmp__(self, evr):
+        if isinstance(evr, str):
+            evr = stringToVersion(evr)
+        else:
+            raise TypeError('PackageVersion compares to "[E:]V[-R]" string')
+
+        if evr[2] is None:
+            pkg_evr = (self.evr[0], self.evr[1], None)
+        else:
+            pkg_evr = self.evr
+
+        return rpm.labelCompare(pkg_evr, evr)
+
+
 # ------------------------------------------------------------------------------
 # Global Functions
 # ------------------------------------------------------------------------------

--- a/osgtest/library/voms.py
+++ b/osgtest/library/voms.py
@@ -150,8 +150,7 @@ def is_installed():
 
     # TODO: drop this check when 3.3 is completely EOL
     if core.el_release() >= 7:
-        epoch, _, version, release, _ = core.get_package_envra('voms-server')
-        if core.version_compare((epoch, version, release), '2.0.12-3.2') < 0:
+        if core.PackageVersion('voms-server') < '2.0.12-3.2':
             core.log_message("voms-server installed but too old (missing SOFTWARE-2357 fix)")
             return False
 

--- a/osgtest/tests/test_140_lcmaps.py
+++ b/osgtest/tests/test_140_lcmaps.py
@@ -22,7 +22,7 @@ class TestLcMaps(osgunittest.OSGTestCase):
 
     def test_02_old_xrootd_policy(self):
         core.skip_ok_unless_installed('xrootd-lcmaps', *self.required_rpms)
-        self.skip_ok_if(core.package_version_compare('xrootd-lcmaps', '1.4.0') >= 0)
+        self.skip_ok_if(core.PackageVersion('xrootd-lcmaps') >= '1.4.0')
 
         files.append(core.config['lcmaps.db'],
                      '''xrootd_policy:

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -53,7 +53,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         if all([core.rpm_is_installed(x) for x in lcmaps_packages]):
             core.log_message("Using xrootd-lcmaps authentication")
             sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,5'
-            if core.package_version_compare('xrootd-lcmaps', '1.4.0') >= 0:
+            if core.PackageVersion('xrootd-lcmaps') >= '1.4.0':
                 sec_protocol += ',--policy,authorize_only'
         else:
             core.log_message("Using XRootD mapfile authentication")

--- a/osgtest/tests/test_230_gratia.py
+++ b/osgtest/tests/test_230_gratia.py
@@ -30,39 +30,6 @@ class TestStartGratia(osgunittest.OSGTestCase):
         shutil.move(outfile_name, infile_name)
 
 
-    def tuple_cmp(self, t1, t2):
-        """ This tuple comparsion method assumes:
-     A. Tuple has 3 entries
-     B. An integer comparsion is desired
-     Note that the python "cmp" method does NOT perform integer comparison
-     Similar to python "cmp" method,
-     The return value is negative if t1 < t2, zero if t1 == t2 and strictly positive if t1 > t2."""
-
-        t1_0 = int(t1[0])
-        t1_1 = int(t1[1])
-        t1_2 = int(t1[2])
-
-        t2_0 = int(t2[0])
-        t2_1 = int(t2[1])
-        t2_2 = int(t2[2])
-
-        if t1_0 < t2_0:
-            return -1
-        elif t1_0 > t2_0:
-            return 1
-        else: #t1_0 == t2_0
-            if t1_1 < t2_1:
-                return -1
-            elif t1_1 > t2_1:
-                return 1
-            else: #t1_1 == t2_1
-                if t1_2 < t2_2:
-                    return -1
-                elif t1_2 > t2_2:
-                    return 1
-                else: #t1_2 == t2_2
-                    return 0
-
     #This test preserves the mentioned gratia directory, if it exists
     def test_01_backup_varlibgratia(self):
         core.skip_ok_unless_installed('gratia-service')

--- a/osgtest/tests/test_230_gratia.py
+++ b/osgtest/tests/test_230_gratia.py
@@ -85,10 +85,7 @@ class TestStartGratia(osgunittest.OSGTestCase):
         core.config['gratia.host'] = core.get_hostname()
         core.config['gratia.config.dir'] = '/etc/gratia'
         # The name of the gratia directory changed
-        gratia_version = core.get_package_envra('gratia-service')[2]
-        gratia_version_split = gratia_version.split('.')
-
-        if self.tuple_cmp(gratia_version_split, ['1', '13', '5']) < 0:
+        if core.PackageVersion('gratia-service') < '1.13.5':
             core.config['gratia.directory'] = "collector"
         else:
             core.config['gratia.directory'] = "services"

--- a/osgtest/tests/test_410_jobs.py
+++ b/osgtest/tests/test_410_jobs.py
@@ -3,7 +3,6 @@
 #pylint: disable=R0904
 
 import os
-import rpm
 import shutil
 import tempfile
 
@@ -49,11 +48,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
         # Figure out whether the installed BLAHP package is the same as or later
         # than "blahp-1.18.11.bosco-4.osg*" (in the RPM sense), because it's the
         # first build in which the job environments are correctly passed to PBS.
-        # The release following "osg" does not matter and it is easier to ignore
-        # the OS major version.  This code may be a useful starting point for a
-        # more general library function.
-        blahp_envra = core.get_package_envra('blahp')
-        blahp_pbs_has_env_vars = (rpm.labelCompare(['blahp', '1.18.11.bosco', '4.osg'], blahp_envra[1:4]) <= 0)
+        blahp_pbs_has_env_vars = core.PackageVersion('blahp') >= '1.18.11.bosco-4.osg'
 
         self.run_job_in_tmp_dir(command, 'condor_run a Condor job', verify_environment=blahp_pbs_has_env_vars)
 

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -84,7 +84,7 @@ class TestStashCache(OSGTestCase):
 
     def test_05_stashcp(self):
         command = ["stashcp", "-d"]
-        if core.package_version_compare('stashcache-client', '5.1.0-5') < 0:
+        if core.PackageVersion('stashcache-client') < '5.1.0-5':
             command.append("--cache=root://localhost")
         name, contents = self.testfiles[3]
         with tempfile.NamedTemporaryFile(mode="r+b") as tf:

--- a/osgtest/tests/test_540_gratia.py
+++ b/osgtest/tests/test_540_gratia.py
@@ -193,8 +193,7 @@ class TestGratia(osgunittest.OSGTestCase):
     def test_03_show_gratia_database_tables(self):
         core.skip_ok_unless_installed('gratia-service')
         command = "echo \"use gratia_osgtest;show tables;" + core.config['gratia.sql.querystring'] + "| wc -l",
-        gratia_version = tuple(map(int, core.get_package_envra('gratia-service')[2].split('.')))
-        if gratia_version >= (1, 16, 3):
+        if core.PackageVersion('gratia-service') >= '1.16.3':
             expected_table_count = '82'
         else:
             expected_table_count = '81'
@@ -227,7 +226,7 @@ class TestGratia(osgunittest.OSGTestCase):
             core.state['gratia.log.stat'] = core.get_stat(core.config['gratia.log.file'])
             core.log_message('stat.st_ino is: ' + str(core.state['gratia.log.stat'].st_ino))
             core.log_message('stat.st_size is: ' + str(core.state['gratia.log.stat'].st_size))
-        if core.package_version_compare('gratia-probe-gridftp-transfer', '1.17.0-1') >= 0:
+        if core.PackageVersion('gratia-probe-gridftp-transfer') >= '1.17.0-1':
             probe_script = 'gridftp-transfer_meter'
         else:
             probe_script = 'GridftpTransferProbeDriver'


### PR DESCRIPTION
This simplifies all of our package version checks with a helper class, which will compare the installed rpm version of a package to an `[E:]V[-R]` version string, in similar style with how version requirements are specified in rpm spec files.

The docstring for the new `PackageVersion` class provides usage examples.

This is a drop-in replacement for our (significantly less readable) existing version checks.

VMU test shows it looks fine, with the same results as the nightlies anyway:

http://vdt.cs.wisc.edu/tests/20181230-1900/packages.html

(... had this code sitting around since Sept, would like to finally get it in...)