### PR TITLE
python3 support for PackageVersion, for Mat

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -107,6 +107,14 @@ class PackageVersion:
 
         return rpm.labelCompare(pkg_evr, evr)
 
+    if not hasattr(__builtins__, 'cmp'):
+        def __eq__(self, evr): return self.__cmp__(evr) == 0
+        def __ne__(self, evr): return self.__cmp__(evr) != 0
+        def __lt__(self, evr): return self.__cmp__(evr) <  0
+        def __le__(self, evr): return self.__cmp__(evr) <= 0
+        def __gt__(self, evr): return self.__cmp__(evr) >  0
+        def __ge__(self, evr): return self.__cmp__(evr) >= 0
+
 
 # ------------------------------------------------------------------------------
 # Global Functions


### PR DESCRIPTION
apparently `cmp()` and `__cmp__()` go away in python3, so you have to implement the other operators yourself.

@matyasselmeci said he wanted python3 support in osg-test, even now.

In fact you can't even get the python3 versions of the rpm modules (`rpm` and `rpmUtils`) on rhel7 + epel7, with python3 installed.  Mat said It can be done (tm) on fedora; so Mat, i'll leave it to you to test this.

As you can see, this non-`__cmp__` based sorting was trivial to add, but (as i also said to Mat when he bugged me about this), Why the python folks found cmp-based ordering so religiously objectionable that they removed it from the language is beyond me.