### PR TITLE
Fixes for osg-test-log-viewer

### DIFF
--- a/osg-test-log-viewer
+++ b/osg-test-log-viewer
@@ -13,6 +13,12 @@ import subprocess
 import sys
 
 
+OK_FAIL_COMMAND_PATTERNS = [
+    # These commands don't get highlighted if they return nonzero
+    "rpm --query",
+    "systemctl is-active",
+    r"service\s+\S+\s+status"
+]
 
 
 class Section(object):
@@ -63,10 +69,10 @@ def load_logdata_from_handle(handle):
                     current_test = match.group('test')
 
                 retcode, _, _ = match.group('result').split()
-                if int(retcode) != 0 and 'rpm --query' not in match.group('command'):
-                    color = "red"
-                else:
-                    color = "black"
+                color = "black"
+                if int(retcode) != 0:
+                    if not any(re.search(pattern, match.group('command')) for pattern in OK_FAIL_COMMAND_PATTERNS):
+                        color = "red"
                 section = Section('    ' + match.group('lineno') + ':' + match.group('command'), color=color)
             else:
                 section = Section(match.group(1))

--- a/osg-test-log-viewer
+++ b/osg-test-log-viewer
@@ -7,9 +7,7 @@ from six.moves.tkinter import *
 from six.moves import tkinter_scrolledtext as ScrolledText
 from six.moves import tkinter_font as tkFont
 from six.moves import urllib
-import os
 import re
-import subprocess
 import sys
 
 
@@ -193,7 +191,7 @@ def main():
         logdata = load_logdata_from_url(logpath)
     root = Tk()
     root.wm_title("osg-test log viewer: " + logpath)
-    app = Application(root, logpath, logdata)
+    Application(root, logpath, logdata)
     root.mainloop()
 
 if __name__ == '__main__':

--- a/osg-test-log-viewer
+++ b/osg-test-log-viewer
@@ -95,8 +95,11 @@ def load_logdata_from_url(url):
     try:
         urlhandle = urllib.request.urlopen(url)
         return load_logdata_from_handle(urlhandle)
-    except urllib.error as e:
-        print("Error reading URL %s: %s" % (url, e.strerror), file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        print("HTTP error code %d reading URL %s: %s" % (e.code, url, e.reason), file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print("Error reading URL %s: %s" % (url, e.reason), file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
The most user-visible change is that `systemctl is-active` and `service ... status` commands are no longer highlighted in red if they return non-zero. Also has some fixes for error handling.