### PR TITLE
Rewrite stashcache tests to work with xcache >= 1.0.2

### DIFF
--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -31,6 +31,9 @@ u xrootd /tmp a
 
 class TestStartXrootd(osgunittest.OSGTestCase):
 
+    def setUp(self):
+        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+
     def test_01_start_xrootd(self):
         core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'
         core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -32,7 +32,8 @@ u xrootd /tmp a
 class TestStartXrootd(osgunittest.OSGTestCase):
 
     def setUp(self):
-        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_start_xrootd(self):
         core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'

--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -120,7 +120,8 @@ class TestStartStashCache(OSGTestCase):
                                       "stash-cache",
                                       "stashcache-client",
                                       by_dependency=True)
-        self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2", "needs xcache 1.0.2+")
 
     def test_01_configure(self):
         for key, val in PARAMS.items():

--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -7,154 +7,174 @@ from osgtest.library.osgunittest import OSGTestCase
 from osgtest.library import service
 
 
-CACHE_DIR = "/tmp/sccache"
-CACHE_XROOT_PORT = 1094  # can't change this - stashcp doesn't allow you to specify port
-CACHE_HTTP_PORT = 8001
-ORIGIN_XROOT_PORT = 1095
-ORIGIN_DIR = "/tmp/scorigin"
-CACHE_AUTHFILE_PATH = "/etc/xrootd/Authfile-cache"
-CACHE_CONFIG_PATH = "/etc/xrootd/xrootd-stashcache-cache-server.cfg"
-ORIGIN_CONFIG_PATH = "/etc/xrootd/xrootd-stashcache-origin-server.cfg"
-CACHES_JSON_PATH = "/etc/stashcache/caches.json"
+# These will end up as environment variables in the xrootd configs
+# as well core.config["stashcache.KEY"] = var
+# Xrootd config syntax doesn't allow underscores so this is CamelCase.
+PARAMS = dict(
+    CacheRootdir              = "/tmp/sccache",
+    CacheXrootPort            = 1094,  # can't change this - stashcp doesn't allow you to specify port
+    CacheHTTPPort             = 8001,
+    CacheHTTPSPort            = 8444,
+    OriginXrootPort           = 1095,
+    OriginAuthXrootPort       = 1096,
+    OriginRootdir             = "/tmp/scorigin",
+    OriginExport              = "/osgtest/PUBLIC",
+    OriginAuthExport          = "/osgtest/PROTECTED",
+    OriginDummyExport         = "/osgtest/dummy",
+    # ^ originexport needs to be defined on caches too because they use the same config.d
+    #   This is relative to CacheRootdir, not OriginRootdir
+    StashOriginAuthfile       = "/etc/xrootd/Authfile-origin",
+    StashOriginPublicAuthfile = "/etc/xrootd/Authfile-origin-public",
+    StashCacheAuthfile        = "/etc/xrootd/Authfile-cache",
+    StashCachePublicAuthfile  = "/etc/xrootd/Authfile-cache-public",
+    OriginResourcename        = "OSG_TEST_ORIGIN",
+    CacheResourcename         = "OSG_TEST_CACHE",
+)
 
+PARAMS_CFG_PATH = "/etc/xrootd/config.d/01-params.cfg"
+# Some statements can take env vars on the right hand side (setenv); others take config vars (set)
+# so define both.
+PARAMS_CFG_CONTENTS = "\n".join("setenv {0} = {1}\nset {0} = {1}".format(k, v)
+                                for k, v in PARAMS.items()) + "\n"
 
-# TODO Set up authenticated stashcache as well
-CACHE_CONFIG_TEXT = """\
-all.export  /
-set cachedir = {CACHE_DIR}
-xrd.allow host *
-sec.protocol  host
-all.adminpath /var/spool/xrootd
+PRE_CFG_PATH = "/etc/xrootd/config.d/11-pre.cfg"
+PRE_CFG_CONTENTS = """
+set DisableOsgMonitoring = 1
 
-xrootd.trace emsg login stall redirect
-ofs.trace all
-xrd.trace all
-cms.trace all
+if named stash-cache-auth
+    xrd.port $(CacheHTTPSPort)
+    set rootdir = $(CacheRootdir)
+    set resourcename = $(CacheResourcename)
+    set originexport = $(OriginDummyExport)
+    
+    ofs.osslib libXrdPss.so
+    pss.cachelib libXrdFileCache.so
 
-ofs.osslib  libXrdPss.so
-# normally this is the redirector but we don't have one in this environment
-pss.origin localhost:{ORIGIN_XROOT_PORT}
-pss.cachelib libXrdFileCache.so
-pss.setopt DebugLevel 1
+    pss.origin localhost:$(OriginAuthXrootPort)
+    xrd.protocol http:$(CacheHTTPSPort) libXrdHttp.so
+else if named stash-cache
+    xrd.port $(CacheXrootPort)
+    set rootdir = $(CacheRootdir)
+    set resourcename = $(CacheResourcename)
+    set originexport = $(OriginDummyExport)
 
-oss.localroot $(cachedir)
+    ofs.osslib libXrdPss.so
+    pss.cachelib libXrdFileCache.so
 
-pfc.blocksize 512k
-pfc.ram       1024m
-# ^ xrootd won't start without a gig
-pfc.prefetch  10
-pfc.diskusage 0.90 0.95
-
-ofs.authorize 1
-acc.audit deny grant
-
-acc.authdb {CACHE_AUTHFILE_PATH}
-sec.protbind * none
-xrd.protocol http:{CACHE_HTTP_PORT} libXrdHttp.so
-
-xrd.port {CACHE_XROOT_PORT}
-
-http.listingdeny yes
-http.staticpreload http://static/robots.txt /etc/xrootd/stashcache-robots.txt
-
-# Tune the client timeouts to more aggressively timeout.
-pss.setopt ParallelEvtLoop 10
-pss.setopt RequestTimeout 25
-#pss.setopt TimeoutResolution 1
-pss.setopt ConnectTimeout 25
-pss.setopt ConnectionRetry 2
-#pss.setopt StreamTimeout 35
-
-all.sitename osgtest
-
-xrootd.diglib * /etc/xrootd/digauth.cf
-""".format(**globals())
-
-
-CACHE_AUTHFILE_TEXT = """\
-u * / rl
+    pss.origin localhost:$(OriginXrootPort)
+    xrd.protocol http:$(CacheHTTPPort) libXrdHttp.so
+else if named stash-origin-auth
+    xrd.port $(OriginAuthXrootPort)
+    set rootdir = $(OriginRootdir)
+    set resourcename = $(OriginResourcename)
+    set originexport = $(OriginAuthExport)
+else if named stash-origin
+    xrd.port $(OriginXrootPort)
+    set rootdir = $(OriginRootdir)
+    set resourcename = $(OriginResourcename)
+    set originexport = $(OriginExport)
+fi
 """
 
+CACHE_AUTHFILE_PATH = PARAMS["StashCacheAuthfile"]
+CACHE_AUTHFILE_CONTENTS = "u * / rl\n"
 
-ORIGIN_CONFIG_TEXT = """\
-xrd.allow host *
-sec.protocol  host
-sec.protbind  * none
-all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+CACHE_PUBLIC_AUTHFILE_PATH = PARAMS["StashCachePublicAuthfile"]
+CACHE_PUBLIC_AUTHFILE_CONTENTS = "u * / rl\n"
 
-# The directory on local disk containing the files to share, e.g. "/stash".
-oss.localroot {ORIGIN_DIR}
-all.export /
+ORIGIN_AUTHFILE_PATH = PARAMS["StashOriginAuthfile"]
+ORIGIN_AUTHFILE_CONTENTS = "u * /osgtest/PROTECTED rl\n"
 
-xrd.port {ORIGIN_XROOT_PORT}
-all.role server
+ORIGIN_PUBLIC_AUTHFILE_PATH = PARAMS["StashOriginPublicAuthfile"]
+ORIGIN_PUBLIC_AUTHFILE_CONTENTS = "u * /osgtest/PUBLIC rl\n"
 
-xrootd.trace emsg login stall redirect
-ofs.trace all
-xrd.trace all
-cms.trace all
-""".format(**globals())
-
-
-CACHES_JSON_TEXT = """\
+CACHES_JSON_PATH = "/etc/stashcache/caches.json"
+CACHES_JSON_CONTENTS = """\
 [
 {"name":"root://localhost", "status":1, "longitude":-89.4012, "latitude":43.0731}
 ]
 """
 
-
-_NAMESPACE = "stashcache"
-
-
-def _getcfg(key):
-    return core.config["%s.%s" % (_NAMESPACE, key)]
+XROOTD_ORIGIN_CFG_PATH = "/etc/xrootd/xrootd-stash-origin.cfg"
+HTTP_CFG_PATH = "/etc/xrootd/config.d/40-osg-http.cfg"
+CACHING_PLUGIN_CFG_PATH = "/etc/xrootd/config.d/40-osg-caching-plugin.cfg"
 
 
-def _setcfg(key, val):
-    core.config["%s.%s" % (_NAMESPACE, key)] = val
+NAMESPACE = "stashcache"
+
+
+# TODO Set up /etc/grid-security/xrd/xrd{key,cert}.pem then uncomment test_05_start_stash_cache_auth
+
+def setcfg(key, val):
+    core.config["%s.%s" % (NAMESPACE, key)] = val
+
+
+def start_xrootd(instance):
+    svc = "xrootd@%s" % instance
+    if not service.is_running(svc):
+        service.check_start(svc)
 
 
 class TestStartStashCache(OSGTestCase):
     @core.elrelease(7,8)
     def setUp(self):
-        core.skip_ok_unless_installed("stashcache-origin-server",
-                                      "stashcache-cache-server",
+        core.skip_ok_unless_installed("stash-origin",
+                                      "stash-cache",
                                       "stashcache-client",
                                       by_dependency=True)
+        self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2")
 
     def test_01_configure(self):
-        for key, val in [
-            ("cache_authfile_path", CACHE_AUTHFILE_PATH),
-            ("cache_config_path", CACHE_CONFIG_PATH),
-            ("origin_config_path", ORIGIN_CONFIG_PATH),
-            ("caches_json_path", CACHES_JSON_PATH),
-            ("cache_http_port", CACHE_HTTP_PORT),
-            ("origin_dir", ORIGIN_DIR),
-            ("cache_dir", CACHE_DIR),
-            ("origin_xroot_port", ORIGIN_XROOT_PORT),
-            ("cache_xroot_port", CACHE_XROOT_PORT)
-        ]:
-            _setcfg(key, val)
+        for key, val in PARAMS.items():
+            setcfg(key, val)
 
-        xrootd_user = pwd.getpwnam("xrootd")
-        for d in [_getcfg("origin_dir"), _getcfg("cache_dir"),
-                  os.path.dirname(_getcfg("caches_json_path"))]:
+        # Create dirs
+        for d in [PARAMS["OriginRootdir"],
+                  PARAMS["CacheRootdir"],
+                  os.path.join(PARAMS["OriginRootdir"], PARAMS["OriginExport"].lstrip("/")),
+                  os.path.join(PARAMS["OriginRootdir"], PARAMS["OriginAuthExport"].lstrip("/")),
+                  os.path.join(PARAMS["CacheRootdir"], PARAMS["OriginDummyExport"].lstrip("/")),
+                  os.path.dirname(CACHES_JSON_PATH)]:
             files.safe_makedirs(d)
-            os.chown(d, xrootd_user.pw_uid, xrootd_user.pw_gid)
 
-        for key, text in [
-            ("cache_config_path", CACHE_CONFIG_TEXT),
-            ("cache_authfile_path", CACHE_AUTHFILE_TEXT),
-            ("origin_config_path", ORIGIN_CONFIG_TEXT),
-            ("caches_json_path", CACHES_JSON_TEXT)
+        core.system(["chown", "-R", "xrootd:xrootd", PARAMS["OriginRootdir"], PARAMS["CacheRootdir"]])
+
+        filelist = []
+        setcfg("filelist", filelist)
+        # Modify filelist in-place with .append so changes get into core.config too
+
+        # Delete the lines we can't override
+        for path, regexp in [
+            (XROOTD_ORIGIN_CFG_PATH, "^\s*all.manager.+$"),
+            (HTTP_CFG_PATH, "^\s*xrd.protocol.+$"),
+            (CACHING_PLUGIN_CFG_PATH, "^\s*(ofs.osslib|pss.cachelib|pss.origin).+$"),
         ]:
-            files.write(_getcfg(key), text, owner=_NAMESPACE, chmod=0o644)
+            files.replace_regexpr(path, regexp, "", owner=NAMESPACE)
+            filelist.append(path)
 
-    def test_02_start_origin(self):
-        if not service.is_running("xrootd@stashcache-origin-server"):
-            service.check_start("xrootd@stashcache-origin-server")
+        # Write our new files
+        for path, contents in [
+            (PARAMS_CFG_PATH, PARAMS_CFG_CONTENTS),
+            (PRE_CFG_PATH, PRE_CFG_CONTENTS),
+            (ORIGIN_AUTHFILE_PATH, ORIGIN_AUTHFILE_CONTENTS),
+            (ORIGIN_PUBLIC_AUTHFILE_PATH, ORIGIN_PUBLIC_AUTHFILE_CONTENTS),
+            (CACHE_AUTHFILE_PATH, CACHE_AUTHFILE_CONTENTS),
+            (CACHE_PUBLIC_AUTHFILE_PATH, CACHE_PUBLIC_AUTHFILE_CONTENTS),
+            (CACHES_JSON_PATH, CACHES_JSON_CONTENTS)
+        ]:
+            files.write(path, contents, owner=NAMESPACE, chmod=0o644)
+            filelist.append(path)
 
-    def test_03_start_cache(self):
-        if not service.is_running("xrootd@stashcache-cache-server"):
-            service.check_start("xrootd@stashcache-cache-server")
+    def test_02_start_stash_origin(self):
+        start_xrootd("stash-origin")
+
+    def test_03_start_stash_origin_auth(self):
+        start_xrootd("stash-origin-auth")
+
+    def test_04_start_stash_cache(self):
+        start_xrootd("stash-cache")
+
+    # def test_05_start_stash_cache_auth(self):
+    #     self.skip_ok("Skipping until I get xrootd-renew-proxy working")
+    #     start_xrootd("stash-cache-auth")
+

--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -103,8 +103,6 @@ CACHING_PLUGIN_CFG_PATH = "/etc/xrootd/config.d/40-osg-caching-plugin.cfg"
 NAMESPACE = "stashcache"
 
 
-# TODO Set up /etc/grid-security/xrd/xrd{key,cert}.pem then uncomment test_05_start_stash_cache_auth
-
 def setcfg(key, val):
     core.config["%s.%s" % (NAMESPACE, key)] = val
 
@@ -165,6 +163,13 @@ class TestStartStashCache(OSGTestCase):
             files.write(path, contents, owner=NAMESPACE, chmod=0o644)
             filelist.append(path)
 
+        # Install certs.  Normally done in the xrootd tests but they conflict with the StashCache tests
+        # (both use the same config dir)
+        core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'
+        core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'
+        core.install_cert('certs.xrootdcert', 'certs.hostcert', 'xrootd', 0o644)
+        core.install_cert('certs.xrootdkey', 'certs.hostkey', 'xrootd', 0o400)
+
     def test_02_start_stash_origin(self):
         start_xrootd("stash-origin")
 
@@ -174,7 +179,5 @@ class TestStartStashCache(OSGTestCase):
     def test_04_start_stash_cache(self):
         start_xrootd("stash-cache")
 
-    # def test_05_start_stash_cache_auth(self):
-    #     self.skip_ok("Skipping until I get xrootd-renew-proxy working")
-    #     start_xrootd("stash-cache-auth")
-
+    def test_05_start_stash_cache_auth(self):
+        start_xrootd("stash-cache-auth")

--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -50,6 +50,9 @@ all.sitename VDTTESTSITE
 """
 
 class TestStartXrootdTPC(osgunittest.OSGTestCase):
+    def setUp(self):
+        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+
     @core.elrelease(7,8)
     def test_01_configure_xrootd(self):
         core.config['xrootd.tpc.config-1'] = '/etc/xrootd/xrootd-third-party-copy-1.cfg'

--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -51,7 +51,8 @@ all.sitename VDTTESTSITE
 
 class TestStartXrootdTPC(osgunittest.OSGTestCase):
     def setUp(self):
-        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     @core.elrelease(7,8)
     def test_01_configure_xrootd(self):

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -14,6 +14,9 @@ class TestXrootd(osgunittest.OSGTestCase):
     __data_path = '/usr/share/osg-test/test_gridftp_data.txt'
     __fuse_path = '/mnt/xrootd_fuse_test'
 
+    def setUp(self):
+        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+
     def test_01_xrdcp_local_to_server(self):
         core.state['xrootd.copied-to-server'] = False
         core.skip_ok_unless_installed('xrootd', 'xrootd-client', by_dependency=True)

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -15,7 +15,8 @@ class TestXrootd(osgunittest.OSGTestCase):
     __fuse_path = '/mnt/xrootd_fuse_test'
 
     def setUp(self):
-        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_xrdcp_local_to_server(self):
         core.state['xrootd.copied-to-server'] = False

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -45,7 +45,8 @@ class TestStashCache(OSGTestCase):
                                       "stash-cache",
                                       "stashcache-client",
                                       by_dependency=True)
-        self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2", "needs xcache 1.0.2+")
         self.skip_bad_unless_running("xrootd@stash-origin", "xrootd@stash-cache")
 
     def test_01_create_files(self):

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -13,15 +13,13 @@ except ImportError:
     from urllib.request import urlopen
 
 
-_NAMESPACE = "stashcache"
+NAMESPACE = "stashcache"
 
-def _getcfg(key):
-    return core.config["%s.%s" % (_NAMESPACE, key)]
-
-def _setcfg(key, val):
-    core.config["%s.%s" % (_NAMESPACE, key)] = val
+def getcfg(key):
+    return core.config["%s.%s" % (NAMESPACE, key)]
 
 
+# TODO Work with authed origin/cache as well.  A separate class would probably be the best.
 class TestStashCache(OSGTestCase):
     # testfiles with random contents
     testfiles = [
@@ -30,7 +28,7 @@ class TestStashCache(OSGTestCase):
     ]
 
     def assertCached(self, name, contents):
-        fpath = os.path.join(_getcfg("cache_dir"), name)
+        fpath = os.path.join(getcfg("CacheRootdir"), getcfg("OriginExport").lstrip("/"), name)
         self.assertTrue(os.path.exists(fpath),
                         name + " not cached")
         self.assertEqualVerbose(actual=files.read(fpath, as_single_string=True),
@@ -43,38 +41,35 @@ class TestStashCache(OSGTestCase):
 
     @core.elrelease(7,8)
     def setUp(self):
-        core.skip_ok_unless_installed("stashcache-origin-server",
-                                      "stashcache-cache-server",
+        core.skip_ok_unless_installed("stash-origin",
+                                      "stash-cache",
                                       "stashcache-client",
                                       by_dependency=True)
-        if core.rpm_is_installed('xcache'):
-            origin_service = "xrootd@stash-origin"
-            cache_service = "xrootd@stash-cache"
-        else:
-            origin_service = "xrootd@stashcache-origin-server"
-            cache_service = "xrootd@stashcache-cache-server"
-        self.skip_bad_unless_running(origin_service, cache_service)
+        self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2")
+        self.skip_bad_unless_running("xrootd@stash-origin", "xrootd@stash-cache")
 
     def test_01_create_files(self):
         xrootd_user = pwd.getpwnam("xrootd")
         for name, contents in self.testfiles:
-            files.write(os.path.join(_getcfg("origin_dir"), name),
+            files.write(os.path.join(getcfg("OriginRootdir"), getcfg("OriginExport").lstrip("/"), name),
                         contents, backup=False, chmod=0o644,
                         chown=(xrootd_user.pw_uid, xrootd_user.pw_gid))
 
     def test_02_xroot_fetch_from_origin(self):
         name, contents = self.testfiles[0]
+        path = os.path.join(getcfg("OriginExport"), name)
         result, _, _ = \
             core.check_system(["xrdcp", "-d1", "-N", "-f",
-                               "root://localhost:%d//%s" % (_getcfg("origin_xroot_port"), name),
+                               "root://localhost:%d/%s" % (getcfg("OriginXrootPort"), path),
                                "-"], "Checking xroot copy from origin")
         self.assertEqualVerbose(result, contents, "downloaded file mismatch")
 
     def test_03_http_fetch_from_cache(self):
         name, contents = self.testfiles[1]
+        path = os.path.join(getcfg("OriginExport"), name)
         try:
             f = urlopen(
-                "http://localhost:%d/%s" % (_getcfg("cache_http_port"), name)
+                "http://localhost:%d/%s" % (getcfg("CacheHTTPPort"), path)
             )
             result = f.read()
         except IOError as e:
@@ -84,9 +79,10 @@ class TestStashCache(OSGTestCase):
 
     def test_04_xroot_fetch_from_cache(self):
         name, contents = self.testfiles[2]
+        path = os.path.join(getcfg("OriginExport"), name)
         result, _, _ = \
             core.check_system(["xrdcp", "-d1", "-N", "-f",
-                               "root://localhost:%d//%s" % (_getcfg("cache_xroot_port"), name),
+                               "root://localhost:%d/%s" % (getcfg("CacheXrootPort"), path),
                                "-"], "Checking xroot copy from cache")
         self.assertEqualVerbose(result, contents, "downloaded file mismatch")
         self.assertCached(name, contents)
@@ -96,8 +92,9 @@ class TestStashCache(OSGTestCase):
         if core.PackageVersion('stashcache-client') < '5.1.0-5':
             command.append("--cache=root://localhost")
         name, contents = self.testfiles[3]
+        path = os.path.join(getcfg("OriginExport"), name)
         with tempfile.NamedTemporaryFile(mode="r+b") as tf:
-            core.check_system(command + ["/"+name, tf.name],
+            core.check_system(command + [path, tf.name],
                               "Checking stashcp")
             result = tf.read()
         self.assertEqualVerbose(result, contents, "stashcp'ed file mismatch")

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -23,7 +23,7 @@ def getcfg(key):
 class TestStashCache(OSGTestCase):
     # testfiles with random contents
     testfiles = [
-        ("testfile%d" % x, str(random.random()))
+        ("testfile%d" % x, str(random.random()) + "\n")
         for x in range(4)
     ]
 

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -10,7 +10,8 @@ import osgtest.library.osgunittest as osgunittest
 class TestXrootdTPC(osgunittest.OSGTestCase):
 
     def setUp(self):
-        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_create_macaroons(self):
         core.skip_ok_unless_installed('xrootd', 'xrootd-scitokens', 'x509-scitokens-issuer-client', by_dependency=True)

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -9,6 +9,9 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestXrootdTPC(osgunittest.OSGTestCase):
 
+    def setUp(self):
+        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+
     def test_01_create_macaroons(self):
         core.skip_ok_unless_installed('xrootd', 'xrootd-scitokens', 'x509-scitokens-issuer-client', by_dependency=True)
         self.skip_bad_unless(core.state['proxy.created'], 'Proxy creation failed')

--- a/osgtest/tests/test_835_stashcache.py
+++ b/osgtest/tests/test_835_stashcache.py
@@ -25,7 +25,8 @@ class TestStopStashCache(OSGTestCase):
                                       "stash-cache",
                                       "stashcache-client",
                                       by_dependency=True)
-        self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") < "1.0.2", "needs xcache 1.0.2+")
 
     def test_01_stop_stash_origin(self):
         stop_xrootd("stash-origin")

--- a/osgtest/tests/test_835_stashcache.py
+++ b/osgtest/tests/test_835_stashcache.py
@@ -47,3 +47,8 @@ class TestStopStashCache(OSGTestCase):
         for key in ["OriginRootdir", "CacheRootdir"]:
             if os.path.isdir(getcfg(key)):
                 shutil.rmtree(getcfg(key))
+
+    def test_07_remove_certs(self):
+        # Do the keys first, so that the directories will be empty for the certs.
+        core.remove_cert('certs.xrootdkey')
+        core.remove_cert('certs.xrootdcert')

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -5,7 +5,8 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestStopXrootdTPC(osgunittest.OSGTestCase):
     def setUp(self):
-        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     @core.elrelease(7,8)
     def test_01_stop_xrootd(self):

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -4,6 +4,9 @@ import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStopXrootdTPC(osgunittest.OSGTestCase):
+    def setUp(self):
+        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+
     @core.elrelease(7,8)
     def test_01_stop_xrootd(self):
         if core.state['xrootd.tpc.backups-exist']:

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -5,7 +5,8 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestStopXrootd(osgunittest.OSGTestCase):
     def setUp(self):
-        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
+        if core.rpm_is_installed("xcache"):
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_stop_xrootd(self):
         if core.state['xrootd.backups-exist']:

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -4,6 +4,8 @@ import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 class TestStopXrootd(osgunittest.OSGTestCase):
+    def setUp(self):
+        self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache conflicts with xrootd tests")
 
     def test_01_stop_xrootd(self):
         if core.state['xrootd.backups-exist']:


### PR DESCRIPTION
Auth cache/origin tests don't work yet; also, to simplify the code, I dropped support for previous versions of xcache.

Tested this out on Fermicloud; need to do a VMU run too.