### PR TITLE
Don't run xrootd-tpc tests on EL6 and also factor out common 'xrootd' dependency

### DIFF
--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -51,6 +51,10 @@ all.sitename VDTTESTSITE
 
 class TestStartXrootdTPC(osgunittest.OSGTestCase):
     @core.elrelease(7,8)
+    def setUp(self):
+        core.skip_ok_unless_installed("xrootd",
+                                      by_dependency=True)
+
     def test_01_configure_xrootd(self):
         core.config['xrootd.tpc.config-1'] = '/etc/xrootd/xrootd-third-party-copy-1.cfg'
         core.config['xrootd.tpc.config-2'] = '/etc/xrootd/xrootd-third-party-copy-2.cfg'
@@ -61,7 +65,7 @@ class TestStartXrootdTPC(osgunittest.OSGTestCase):
         core.state['xrootd.tpc.backups-exist'] = False
 
         self.skip_ok_unless(core.options.adduser, 'user not created')
-        core.skip_ok_unless_installed('globus-proxy-utils', 'xrootd', by_dependency=True)
+        core.skip_ok_unless_installed('globus-proxy-utils', by_dependency=True)
 
         user = pwd.getpwnam("xrootd")
 
@@ -83,7 +87,6 @@ class TestStartXrootdTPC(osgunittest.OSGTestCase):
         core.state['xrootd.tpc.backups-exist'] = True
  
     def test_02_create_secrets(self):
-        core.skip_ok_unless_installed('xrootd', by_dependency=True)
         core.config['xrootd.tpc.macaroon-secret-1'] = '/etc/xrootd/macaroon-secret-1'
         core.config['xrootd.tpc.macaroon-secret-2'] = '/etc/xrootd/macaroon-secret-2'
         core.check_system(["openssl", "rand", "-base64", "-out",
@@ -97,13 +100,10 @@ class TestStartXrootdTPC(osgunittest.OSGTestCase):
                          "macaroons.secretkey %s"%(core.config['xrootd.tpc.macaroon-secret-2']),
                       owner='xrootd', backup=False)
 
-
     def test_03_start_xrootd(self):
-        core.skip_ok_unless_installed('xrootd', by_dependency=True)
         core.config['xrootd_tpc_service_1'] = "xrootd@third-party-copy-1"
         core.config['xrootd_tpc_service_2'] = "xrootd@third-party-copy-2"
         service.check_start(core.config['xrootd_tpc_service_1'], log_to_check = '/var/log/xrootd/third-party-copy-1/xrootd.log')
         service.check_start(core.config['xrootd_tpc_service_2'], log_to_check = '/var/log/xrootd/third-party-copy-2/xrootd.log')
         core.state['xrootd.started-http-server-1'] = True
         core.state['xrootd.started-http-server-2'] = True
-

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -8,9 +8,13 @@ import osgtest.library.osgunittest as osgunittest
 
 
 class TestXrootdTPC(osgunittest.OSGTestCase):
+    @core.elrelease(7,8)
+    def setUp(self):
+        core.skip_ok_unless_installed("xrootd",
+                                      by_dependency=True)
 
     def test_01_create_macaroons(self):
-        core.skip_ok_unless_installed('xrootd', 'x509-scitokens-issuer-client', by_dependency=True)
+        core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
         self.skip_bad_unless(core.state['proxy.created'], 'Proxy creation failed')
         core.config['xrootd.tpc.macaroon-1'] = None
         core.config['xrootd.tpc.macaroon-2'] = None
@@ -37,7 +41,7 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
         core.config['xrootd.tpc.macaroon-2'] = stdout.strip()
         
     def test_02_initate_tpc(self):
-        core.skip_ok_unless_installed('xrootd', 'x509-scitokens-issuer-client', by_dependency=True)
+        core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
         self.skip_bad_if(core.config['xrootd.tpc.macaroon-1'] is None, 'Macaroon creation failed earlier')
         self.skip_bad_if(core.config['xrootd.tpc.macaroon-2'] is None, 'Macaroon creation failed earlier')
         headers = {}

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -5,12 +5,16 @@ import osgtest.library.osgunittest as osgunittest
 
 class TestStopXrootdTPC(osgunittest.OSGTestCase):
     @core.elrelease(7,8)
+    def setUp(self):
+        core.skip_ok_unless_installed("xrootd",
+                                      by_dependency=True)
+
     def test_01_stop_xrootd(self):
         if core.state['xrootd.tpc.backups-exist']:
             files.restore(core.config['xrootd.tpc.config-1'], "xrootd")
             files.restore(core.config['xrootd.tpc.config-2'], "xrootd")
 
-        core.skip_ok_unless_installed('xrootd', 'xrootd-scitokens', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd-scitokens', by_dependency=True)
         self.skip_ok_if(not core.state['xrootd.started-http-server-1'] and 
                         not core.state['xrootd.started-http-server-2'], 
                         'did not start any of the http servers')

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -14,8 +14,7 @@ class TestStopXrootdTPC(osgunittest.OSGTestCase):
             files.restore(core.config['xrootd.tpc.config-1'], "xrootd")
             files.restore(core.config['xrootd.tpc.config-2'], "xrootd")
 
-        core.skip_ok_unless_installed('xrootd-scitokens', by_dependency=True)
-        self.skip_ok_if(not core.state['xrootd.started-http-server-1'] and 
+        self.skip_ok_if(not core.state['xrootd.started-http-server-1'] and
                         not core.state['xrootd.started-http-server-2'], 
                         'did not start any of the http servers')
         service.check_stop(core.config['xrootd_tpc_service_1'])


### PR DESCRIPTION
The setUp method gets used for all the other test functions so common excludes/skip_oks can be placed there instead of being duplicated.