### PR TITLE
Fix Slurm config location

### DIFF
--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -65,7 +65,10 @@ class TestStartSlurm(osgunittest.OSGTestCase):
 
     def test_01_slurm_config(self):
         self.slurm_reqs()
-        core.config['slurm.config'] = '/etc/slurm/slurm.conf'
+        if core.PackageVersion('slurm') >= '19.05.2':
+            core.config['slurm.config'] = '/etc/slurm.conf'
+        else:
+            core.config['slurm.config'] = '/etc/slurm/slurm.conf'
         files.write(core.config['slurm.config'],
                     SLURM_CONFIG % {'short_hostname': SHORT_HOSTNAME, 'cluster': CLUSTER_NAME, 'ctld_log': CTLD_LOG},
                     owner='slurm',


### PR DESCRIPTION
This fixes Slurm setup errors from our [nightlies](http://vdt.cs.wisc.edu/tests/20190820-0423/results.html) [1]. Clean run here: http://vdt.cs.wisc.edu/tests/20190819-1329/results.html

[1]

```
======================================================================
ERROR: test_01_slurm_config (osgtest.tests.test_290_slurm.TestStartSlurm)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/osgtest/library/osgunittest.py", line 196, in run
    testMethod()
  File "/usr/lib/python2.7/site-packages/osgtest/tests/test_290_slurm.py", line 72, in test_01_slurm_config
    chmod=0o644)
  File "/usr/lib/python2.7/site-packages/osgtest/library/files.py", line 105, in write
    dir=os.path.dirname(path))
  File "/usr/lib64/python2.7/tempfile.py", line 304, in mkstemp
    return _mkstemp_inner(dir, prefix, suffix, flags)
  File "/usr/lib64/python2.7/tempfile.py", line 239, in _mkstemp_inner
    fd = _os.open(file, flags, 0600)
OSError: [Errno 2] No such file or directory: '/etc/slurm/slurm.conf.bf9q5j.osgtest-new'
```