### PR TITLE
Use /etc for the Slurm sysconfdir (SOFTWARE-3783)

### DIFF
--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -1,10 +1,9 @@
+import os
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.mysql as mysql
 import osgtest.library.osgunittest as osgunittest
 import osgtest.library.service as service
-
-import time
 
 CLUSTER_NAME = 'osg_test'
 CTLD_LOG = '/var/log/slurm/slurmctld.log'
@@ -66,14 +65,15 @@ class TestStartSlurm(osgunittest.OSGTestCase):
     def test_01_slurm_config(self):
         self.slurm_reqs()
         if core.PackageVersion('slurm') >= '19.05.2':
-            core.config['slurm.config'] = '/etc/slurm.conf'
+            core.config['slurm.config-dir'] = '/etc'
         else:
-            core.config['slurm.config'] = '/etc/slurm/slurm.conf'
+            core.config['slurm.config-dir'] = '/etc/slurm'
+        core.config['slurm.config'] = os.path.join(core.config['slurm.config-dir'], 'slurm.conf')
         files.write(core.config['slurm.config'],
                     SLURM_CONFIG % {'short_hostname': SHORT_HOSTNAME, 'cluster': CLUSTER_NAME, 'ctld_log': CTLD_LOG},
                     owner='slurm',
                     chmod=0o644)
-        core.config['cgroup.config'] = '/etc/slurm/cgroup.conf'
+        core.config['cgroup.config'] = os.path.join(core.config['slurm.config-dir'], 'cgroup.conf')
         config = SLURM_CGROUPS_CONFIG
         if core.el_release() == 6:
             config += "\nCgroupMountpoint=/cgroup"
@@ -82,7 +82,8 @@ class TestStartSlurm(osgunittest.OSGTestCase):
                     owner='slurm',
                     chmod=0o644)
 
-        core.config['cgroup_allowed_devices_file.conf'] = '/etc/slurm/cgroup_allowed_devices_file.conf'
+        core.config['cgroup_allowed_devices_file.conf'] = os.path.join(core.config['slurm.config-dir'],
+                                                                       'cgroup_allowed_devices_file.conf')
         files.write(core.config['cgroup_allowed_devices_file.conf'],
                     SLURM_CGROUPS_DEVICE_CONFIG,
                     owner='slurm',
@@ -93,7 +94,7 @@ class TestStartSlurm(osgunittest.OSGTestCase):
         self.slurm_reqs()
         core.skip_ok_unless_installed('slurm-slurmdbd')
         self.skip_bad_unless(mysql.is_running(), 'slurmdbd requires mysql')
-        core.config['slurmdbd.config'] = '/etc/slurm/slurmdbd.conf'
+        core.config['slurmdbd.config'] = os.path.join(core.config['slurm.config-dir'], 'slurmdbd.conf')
         core.config['slurmdbd.user'] = "'osg-test-slurm'@'localhost'"
         core.config['slurmdbd.name'] = "osg_test_slurmdb"
 


### PR DESCRIPTION
We could instead build Slurm with './configure
--sysconfdir=/etc/slurm' (the default is /etc) but I'd like to
minimize the differences between the upstream packaging