### PR TITLE
Use osg-xrootd-standalone in our XRootD tests (SOFTWARE-3520)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,17 @@ git:
   quiet: true
 
 env:
-  - OSG_RELEASE=3.4 OS_VERSION=6 PKG_SET=osg-xrootd-standalone
-  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=osg-xrootd-standalone
-  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=osg-xrootd-standalone
+  - OSG_RELEASE=3.4 OS_VERSION=6 PKG_SET=htcondor-ce
+  - OSG_RELEASE=3.4 OS_VERSION=6 PKG_SET=gridftp
+  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=htcondor-ce
+  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=gridftp
+  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=singularity
+  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=stashcache
   - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=xrootd
+  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=htcondor-ce
+  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=gridftp
+  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=singularity
+  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=stashcache
   - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=xrootd
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,10 @@ git:
   quiet: true
 
 env:
-  - OSG_RELEASE=3.4 OS_VERSION=6 PKG_SET=htcondor-ce
-  - OSG_RELEASE=3.4 OS_VERSION=6 PKG_SET=gridftp
-  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=htcondor-ce
-  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=gridftp
-  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=singularity
-  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=stashcache
+  - OSG_RELEASE=3.4 OS_VERSION=6 PKG_SET=osg-xrootd-standalone
+  - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=osg-xrootd-standalone
+  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=osg-xrootd-standalone
   - OSG_RELEASE=3.4 OS_VERSION=7 PKG_SET=xrootd
-  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=htcondor-ce
-  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=gridftp
-  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=singularity
-  - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=stashcache
   - OSG_RELEASE=3.5 OS_VERSION=7 PKG_SET=xrootd
 
 services:

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -19,6 +19,12 @@ acc.authdb /etc/xrootd/auth_file
 ofs.authorize
 """
 
+# XRootD configuration necessaryfor osg-xrootd-standalone
+META_XROOTD_CFG_TEXT = """\
+set rootdir = /
+set resourcename = OSG_TEST_XROOTD_STANDALONE
+"""
+
 AUTHFILE_TEXT = """\
 u * /tmp a /usr/share/ r
 u = /tmp/@=/ a
@@ -37,8 +43,11 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'
         core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'
         core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'
-        core.config['xrootd.config'] = '/etc/xrootd/xrootd-clustered.cfg'
-        core.config['xrootd.config-extra'] = '/etc/xrootd/config.d/99-osg-test.cfg'
+        if core.rpm_is_installed('osg-xrootd-standalone'):
+            # rootdir and resourcename needs to be set early for the default osg-xrootd config
+            core.config['xrootd.config'] = '/etc/xrootd/config.d/10-osg-test.cfg'
+        else:
+            core.config['xrootd.config'] = '/etc/xrootd/config.d/99-osg-test.cfg'
         core.config['xrootd.multiuser'] = False
         core.state['xrootd.started-server'] = False
         core.state['xrootd.backups-exist'] = False
@@ -51,27 +60,25 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.install_cert('certs.xrootdcert', 'certs.hostcert', 'xrootd', 0o644)
         core.install_cert('certs.xrootdkey', 'certs.hostkey', 'xrootd', 0o400)
 
-        lcmaps_packages = ('lcmaps', 'lcmaps-db-templates', 'xrootd-lcmaps', 'vo-client', 'vo-client-lcmaps-voms')
-        if all([core.rpm_is_installed(x) for x in lcmaps_packages]):
-            core.log_message("Using xrootd-lcmaps authentication")
-            sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,5'
-            if core.PackageVersion('xrootd-lcmaps') >= '1.4.0':
-                sec_protocol += ',--policy,authorize_only'
+        if core.rpm_is_installed('osg-xrootd-standalone'):
+            core.log_message("Using osg-xrootd configuration")
+            xrootd_config = META_XROOTD_CFG_TEXT
         else:
-            core.log_message("Using XRootD mapfile authentication")
-            sec_protocol = '-gridmap:/etc/grid-security/xrd/xrdmapfile'
-            files.write("/etc/grid-security/xrd/xrdmapfile", "\"%s\" vdttest" % core.config['user.cert_subject'],
-                        owner="xrootd",
-                        chown=(user.pw_uid, user.pw_gid))
+            lcmaps_packages = ('lcmaps', 'lcmaps-db-templates', 'xrootd-lcmaps', 'vo-client', 'vo-client-lcmaps-voms')
+            if all([core.rpm_is_installed(x) for x in lcmaps_packages]):
+                core.log_message("Using xrootd-lcmaps authentication")
+                sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,5'
+                if core.PackageVersion('xrootd-lcmaps') >= '1.4.0':
+                    sec_protocol += ',--policy,authorize_only'
+            else:
+                core.log_message("Using XRootD mapfile authentication")
+                sec_protocol = '-gridmap:/etc/grid-security/xrd/xrdmapfile'
+                files.write("/etc/grid-security/xrd/xrdmapfile", "\"%s\" vdttest" % core.config['user.cert_subject'],
+                            owner="xrootd",
+                            chown=(user.pw_uid, user.pw_gid))
+            xrootd_config = XROOTD_CFG_TEXT % sec_protocol
 
-        if core.PackageVersion('xrootd') < '1:4.9.0':
-            files.append(core.config['xrootd.config'],
-                         XROOTD_CFG_TEXT % sec_protocol,
-                         owner='xrootd', backup=True)
-        else:
-            files.write(core.config['xrootd.config-extra'],
-                        XROOTD_CFG_TEXT % sec_protocol,
-                        owner='xrootd', backup=True, chmod=0o644)
+        files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True)
 
         authfile = '/etc/xrootd/auth_file'
         files.write(authfile, AUTHFILE_TEXT, owner="xrootd", chown=(user.pw_uid, user.pw_gid))
@@ -81,18 +88,12 @@ class TestStartXrootd(osgunittest.OSGTestCase):
     def test_02_configure_hdfs(self):
         core.skip_ok_unless_installed('xrootd-hdfs')
         hdfs_config = "ofs.osslib /usr/lib64/libXrdHdfs.so"
-        if core.PackageVersion('xrootd') < '1:4.9.0':
-            files.append(core.config['xrootd.config'], hdfs_config, backup=False)
-        else:
-            files.append(core.config['xrootd.config-extra'], hdfs_config, backup=False)
+        files.append(core.config['xrootd.config'], hdfs_config, backup=False)
 
     def test_03_configure_multiuser(self):
         core.skip_ok_unless_installed('xrootd-multiuser', 'globus-proxy-utils', by_dependency=True)
         xrootd_multiuser_conf = "xrootd.fslib libXrdMultiuser.so default"
-        if core.PackageVersion('xrootd') < '1:4.9.0':
-            files.append(core.config['xrootd.config'], xrootd_multiuser_conf, owner='xrootd', backup=False)
-        else:
-            files.append(core.config['xrootd.config-extra'], xrootd_multiuser_conf, owner='xrootd', backup=False)
+        files.append(core.config['xrootd.config'], xrootd_multiuser_conf, owner='xrootd', backup=False)
         core.config['xrootd.multiuser'] = True
 
     def test_04_start_xrootd(self):
@@ -100,9 +101,9 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         if core.el_release() < 7:
             core.config['xrootd_service'] = "xrootd"
         elif core.config['xrootd.multiuser']:
-            core.config['xrootd_service'] = "xrootd-privileged@clustered"
+            core.config['xrootd_service'] = "xrootd-privileged@standalone"
         else:
-            core.config['xrootd_service'] = "xrootd@clustered"
+            core.config['xrootd_service'] = "xrootd@standalone"
 
         service.check_start(core.config['xrootd_service'])
         core.state['xrootd.started-server'] = True

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -26,11 +26,13 @@ u = /tmp/@=/ a
 u xrootd /tmp a
 """
 
+
 class TestStartXrootd(osgunittest.OSGTestCase):
 
     def setUp(self):
         if core.rpm_is_installed("xcache"):
-            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
+                            "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_start_xrootd(self):
         core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'
@@ -86,7 +88,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             files.append(core.config['xrootd.config-extra'], hdfs_config, backup=False)
 
     def test_03_configure_multiuser(self):
-        core.skip_ok_unless_installed('xrootd-multiuser','globus-proxy-utils', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd-multiuser', 'globus-proxy-utils', by_dependency=True)
         xrootd_multiuser_conf = "xrootd.fslib libXrdMultiuser.so default"
         if core.PackageVersion('xrootd') < '1:4.9.0':
             files.append(core.config['xrootd.config'], xrootd_multiuser_conf, owner='xrootd', backup=False)

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -31,6 +31,21 @@ u = /tmp/@=/ a
 u xrootd /tmp a
 """
 
+SYSCONFIG_TEXT = """\
+XROOTD_USER=xrootd
+XROOTD_GROUP=xrootd
+
+XROOTD_DEFAULT_OPTIONS="-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
+CMSD_DEFAULT_OPTIONS="-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
+PURD_DEFAULT_OPTIONS="-l /var/log/xrootd/purged.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
+XFRD_DEFAULT_OPTIONS="-l /var/log/xrootd/xfrd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
+
+XROOTD_INSTANCES="default"
+CMSD_INSTANCES="default"
+PURD_INSTANCES="default"
+XFRD_INSTANCES="default"
+"""
+
 
 class TestStartXrootd(osgunittest.OSGTestCase):
 
@@ -80,8 +95,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True, chmod=0o644)
 
         if core.el_release() < 7:
-            files.write(core.config['xrootd.service-defaults'],
-                        'XROOTD_DEFAULT_OPTIONS="-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"',
+            files.write(core.config['xrootd.service-defaults'], SYSCONFIG_TEXT,
                         owner="xrootd", chown=(user.pw_uid, user.pw_gid), chmod=0o644)
 
         authfile = '/etc/xrootd/auth_file'

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -67,9 +67,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             lcmaps_packages = ('lcmaps', 'lcmaps-db-templates', 'xrootd-lcmaps', 'vo-client', 'vo-client-lcmaps-voms')
             if all([core.rpm_is_installed(x) for x in lcmaps_packages]):
                 core.log_message("Using xrootd-lcmaps authentication")
-                sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,5'
-                if core.PackageVersion('xrootd-lcmaps') >= '1.4.0':
-                    sec_protocol += ',--policy,authorize_only'
+                sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:loglevel=5,policy=authorize_only'
             else:
                 core.log_message("Using XRootD mapfile authentication")
                 sec_protocol = '-gridmap:/etc/grid-security/xrd/xrdmapfile'

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -48,6 +48,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             core.config['xrootd.config'] = '/etc/xrootd/config.d/10-osg-test.cfg'
         else:
             core.config['xrootd.config'] = '/etc/xrootd/config.d/99-osg-test.cfg'
+        core.config['xrootd.service-defaults'] = '/etc/sysconfig/xrootd'
         core.config['xrootd.multiuser'] = False
         core.state['xrootd.started-server'] = False
         core.state['xrootd.backups-exist'] = False
@@ -77,6 +78,11 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             xrootd_config = XROOTD_CFG_TEXT % sec_protocol
 
         files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True)
+
+        if core.el_release() < 7:
+            files.write(core.config['xrootd.service-defaults'],
+                        'XROOTD_DEFAULT_OPTIONS="-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"',
+                        owner="xrootd", chown=(user.pw_uid, user.pw_gid))
 
         authfile = '/etc/xrootd/auth_file'
         files.write(authfile, AUTHFILE_TEXT, owner="xrootd", chown=(user.pw_uid, user.pw_gid))

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -1,4 +1,3 @@
-import os
 import pwd
 import osgtest.library.core as core
 import osgtest.library.files as files

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -54,7 +54,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
                             "xcache 1.0.2+ configs conflict with xrootd tests")
 
-    def test_01_start_xrootd(self):
+    def test_01_configure_xrootd(self):
         core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'
         core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'
         core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -77,12 +77,12 @@ class TestStartXrootd(osgunittest.OSGTestCase):
                             chown=(user.pw_uid, user.pw_gid))
             xrootd_config = XROOTD_CFG_TEXT % sec_protocol
 
-        files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True)
+        files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True, chmod=0o644)
 
         if core.el_release() < 7:
             files.write(core.config['xrootd.service-defaults'],
                         'XROOTD_DEFAULT_OPTIONS="-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"',
-                        owner="xrootd", chown=(user.pw_uid, user.pw_gid))
+                        owner="xrootd", chown=(user.pw_uid, user.pw_gid), chmod=0o644)
 
         authfile = '/etc/xrootd/auth_file'
         files.write(authfile, AUTHFILE_TEXT, owner="xrootd", chown=(user.pw_uid, user.pw_gid))

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -6,8 +6,6 @@ import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
 
-XROOTD_PORT = 1096  # chosen so it doesn't conflict w/ the stashcache instances
-
 XROOTD_CFG_TEXT = """\
 cms.space min 2g 5g
 xrootd.seclib /usr/lib64/libXrdSec-4.so
@@ -20,7 +18,6 @@ sec.protocol /usr/lib64 gsi -certdir:/etc/grid-security/certificates \
     %s
 acc.authdb /etc/xrootd/auth_file
 ofs.authorize
-xrd.port %d
 """
 
 AUTHFILE_TEXT = """\
@@ -41,7 +38,6 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'
         core.config['xrootd.config'] = '/etc/xrootd/xrootd-clustered.cfg'
         core.config['xrootd.config-extra'] = '/etc/xrootd/config.d/99-osg-test.cfg'
-        core.config['xrootd.port'] = XROOTD_PORT
         core.config['xrootd.multiuser'] = False
         core.state['xrootd.started-server'] = False
         core.state['xrootd.backups-exist'] = False
@@ -69,12 +65,13 @@ class TestStartXrootd(osgunittest.OSGTestCase):
 
         if core.PackageVersion('xrootd') < '1:4.9.0':
             files.append(core.config['xrootd.config'],
-                         XROOTD_CFG_TEXT % (sec_protocol, core.config['xrootd.port']),
+                         XROOTD_CFG_TEXT % sec_protocol,
                          owner='xrootd', backup=True)
         else:
             files.write(core.config['xrootd.config-extra'],
-                        XROOTD_CFG_TEXT % (sec_protocol, core.config['xrootd.port']),
+                        XROOTD_CFG_TEXT % sec_protocol,
                         owner='xrootd', backup=True, chmod=0o644)
+
         authfile = '/etc/xrootd/auth_file'
         files.write(authfile, AUTHFILE_TEXT, owner="xrootd", chown=(user.pw_uid, user.pw_gid))
 

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -16,7 +16,8 @@ class TestXrootd(osgunittest.OSGTestCase):
 
     def setUp(self):
         if core.rpm_is_installed("xcache"):
-            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
+                            "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_xrdcp_local_to_server(self):
         core.state['xrootd.copied-to-server'] = False
@@ -43,11 +44,12 @@ class TestXrootd(osgunittest.OSGTestCase):
         self.assert_(file_copied, 'Copied file missing')
 
     def test_02_xrootd_multiuser(self):
-        core.skip_ok_unless_installed('xrootd', 'xrootd-client', 'globus-proxy-utils', 'xrootd-multiuser', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd', 'xrootd-client', 'globus-proxy-utils', 'xrootd-multiuser',
+                                      by_dependency=True)
         self.skip_bad_unless(core.config['xrootd.multiuser'], 'Xrootd not configured for multiuser')
         self.skip_bad_unless(core.state['xrootd.copied-to-server'], 'File to check ownership does not exist')
         file_path = os.path.join(core.config['xrootd.tmp-dir'], 'copied_file.txt')
-        self.assertEqual(core.check_file_ownership(file_path, core.options.username), True) 
+        self.assertEqual(core.check_file_ownership(file_path, core.options.username), True)
 
     def test_03_xrdcp_server_to_local(self):
         core.skip_ok_unless_installed('xrootd', 'xrootd-client', by_dependency=True)

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -29,7 +29,7 @@ class TestXrootd(osgunittest.OSGTestCase):
         os.chown(temp_dir, user[2], user[3])
         hostname = socket.getfqdn()
         os.chmod(temp_dir, 0o777)
-        xrootd_url = 'root://%s:%d/%s/copied_file.txt' % (hostname, core.config['xrootd.port'], temp_dir)
+        xrootd_url = 'root://%s/%s/copied_file.txt' % (hostname, temp_dir)
         command = ('xrdcp', '--debug', '3', TestXrootd.__data_path, xrootd_url)
 
         status, stdout, stderr = core.system(command, user=True)
@@ -62,7 +62,7 @@ class TestXrootd(osgunittest.OSGTestCase):
         f = open(temp_source_dir + "/copied_file.txt", "w")
         f.write("This is some test data for an xrootd test.")
         f.close()
-        xrootd_url = 'root://%s:%d/%s/copied_file.txt' % (hostname, core.config['xrootd.port'], temp_source_dir)
+        xrootd_url = 'root://%s/%s/copied_file.txt' % (hostname, temp_source_dir)
         local_path = temp_target_dir + '/copied_file.txt'
         command = ('xrdcp', '--debug', '3', xrootd_url, local_path)
 
@@ -86,12 +86,12 @@ class TestXrootd(osgunittest.OSGTestCase):
             os.mkdir(TestXrootd.__fuse_path)
         hostname = socket.getfqdn()
 
-        #For some reason, sub process hangs on fuse processes, use os.system
-        os.system("mount -t fuse -o rdr=root://localhost:%d//tmp,uid=xrootd xrootdfs %s" %
-                  (core.config['xrootd.port'], TestXrootd.__fuse_path))
+        # For some reason, sub process hangs on fuse processes, use os.system
+        os.system("mount -t fuse -o rdr=root://localhost//tmp,uid=xrootd xrootdfs %s" %
+                  TestXrootd.__fuse_path)
 
         # Copy a file in and see if it made it into the fuse mount
-        xrootd_url = 'root://%s:%d/%s/copied_file.txt' % (hostname, core.config['xrootd.port'], "/tmp")
+        xrootd_url = 'root://%s/%s/copied_file.txt' % (hostname, "/tmp")
         core.system(['xrdcp', '--debug', '3', TestXrootd.__data_path, xrootd_url], user=True)
 
         self.assert_(os.path.isfile("/tmp/copied_file.txt"), "Test file not uploaded to FUSE mount")

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -12,10 +12,7 @@ class TestStopXrootd(osgunittest.OSGTestCase):
 
     def test_01_stop_xrootd(self):
         if core.state['xrootd.backups-exist']:
-            if core.PackageVersion('xrootd') < '1:4.9.0':
-                files.restore(core.config['xrootd.config'], "xrootd")
-            else:
-                files.restore(core.config['xrootd.config-extra'], "xrootd")
+            files.restore(core.config['xrootd.config'], "xrootd")
             files.restore('/etc/xrootd/auth_file', "xrootd")
             if not core.rpm_is_installed('xrootd-lcmaps'):
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -16,6 +16,8 @@ class TestStopXrootd(osgunittest.OSGTestCase):
             files.restore('/etc/xrootd/auth_file', "xrootd")
             if not core.rpm_is_installed('xrootd-lcmaps'):
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")
+            if core.el_release() < 7:
+                files.restore(core.config['xrootd.service-defaults'], "xrootd")
         core.skip_ok_unless_installed('xrootd', by_dependency=True)
         self.skip_ok_if(core.state['xrootd.started-server'], 'did not start server')
         service.check_stop(core.config['xrootd_service'])

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -3,10 +3,12 @@ import osgtest.library.files as files
 import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
 
+
 class TestStopXrootd(osgunittest.OSGTestCase):
     def setUp(self):
         if core.rpm_is_installed("xcache"):
-            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
+            self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
+                            "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_stop_xrootd(self):
         if core.state['xrootd.backups-exist']:

--- a/travis-ci/osg-xrootd-standalone.packages
+++ b/travis-ci/osg-xrootd-standalone.packages
@@ -1,0 +1,3 @@
+osg-xrootd-standalone
+xrootd-client
+globus-proxy-utils

--- a/travis-ci/test_inside_docker.sh
+++ b/travis-ci/test_inside_docker.sh
@@ -1,11 +1,11 @@
 #!/bin/sh -xe
 
+extra_repos='--extra-repo=osg-minefield'
+
 if [[ "$OSG_RELEASE" == "3.5" ]]; then
     devops_repo='--enablerepo=devops-itb'
-    extra_repos='--extra-repo=osg-development'
 else
     devops_repo=''
-    extra_repos=''
 fi
 
 ls -l /home

--- a/travis-ci/test_inside_docker.sh
+++ b/travis-ci/test_inside_docker.sh
@@ -76,5 +76,6 @@ osg-test --verbose \
          --dump-output \
          --hostcert \
          --no-cleanup \
+         --manual-run \
          ${extra_repos} \
          ${install_str}


### PR DESCRIPTION
I can revert the changes in the `.travis.yml` parameters once we're ready to merge. CI passes for osg-xrootd-standalone package sets and the former xrootd package sets: https://travis-ci.org/brianhlin/osg-test/builds/575047482