### PR TITLE
Fix osg-tested-internal repos

### DIFF
--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -32,13 +32,15 @@ class TestInstall(osgunittest.OSGTestCase):
 
         # HACK: Install Slurm and osg-tested-internal out of development-like repos.
         # SOFTWARE-1733 may one day give us a generalized solution.
-        devops_repos = ['osg-development']
-        # FIXME: Upon release of OSG 3.5.0, this list does not need to contain osg-development
         if core.osg_release() > '3.4':
-            devops_repos += ['devops-itb']
+            dev_repo = ['devops-itb']
+            if 'osg-tested-internal' in pkg_repo_dict:
+                pkg_repo_dict['osg-tested-internal'] += dev_repo
+        else:
+            dev_repo = ['osg-development']
 
         if 'osg-tested-internal' in pkg_repo_dict or 'slurm' in pkg_repo_dict:
-            pkg_repo_dict.update(dict((x, devops_repos) for x in core.SLURM_PACKAGES + ['osg-tested-internal']))
+            pkg_repo_dict.update(dict((x, core.options.extrarepos + dev_repo) for x in core.SLURM_PACKAGES))
 
         # HACK: Install x509-scitokens-issuer-client out of development (SOFTWARE-3649)
         if 'xrootd-scitokens' in pkg_repo_dict:


### PR DESCRIPTION
- Remove 3.5.0 pre-release hack that was added in '198d85488a342fdb206d9044b4a51cef71bb9d9f'