### PR TITLE
Require globus-proxy-utils for XRootD service mgmt

### DIFF
--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -69,10 +69,9 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.state['xrootd.backups-exist'] = False
 
         self.skip_ok_unless(core.options.adduser, 'user not created')
-        core.skip_ok_unless_installed('xrootd', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd', 'globus-proxy-utils', by_dependency=True)
 
         user = pwd.getpwnam("xrootd")
-        core.skip_ok_unless_installed('globus-proxy-utils')
         core.install_cert('certs.xrootdcert', 'certs.hostcert', 'xrootd', 0o644)
         core.install_cert('certs.xrootdkey', 'certs.hostkey', 'xrootd', 0o400)
 
@@ -115,7 +114,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.config['xrootd.multiuser'] = True
 
     def test_04_start_xrootd(self):
-        core.skip_ok_unless_installed('xrootd', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd', 'globus-proxy-utils', by_dependency=True)
         if core.el_release() < 7:
             core.config['xrootd_service'] = "xrootd"
         elif core.config['xrootd.multiuser']:

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -18,7 +18,7 @@ class TestStopXrootd(osgunittest.OSGTestCase):
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")
             if core.el_release() < 7:
                 files.restore(core.config['xrootd.service-defaults'], "xrootd")
-        core.skip_ok_unless_installed('xrootd', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd', 'globus-proxy-utils', by_dependency=True)
         self.skip_ok_if(core.state['xrootd.started-server'], 'did not start server')
         service.check_stop(core.config['xrootd_service'])
         files.remove(core.config['xrootd.tmp-dir'], force=True)


### PR DESCRIPTION
Noticed when testing osg-xrootd-standalone in SOFTWARE-3587: when
XRootD is installed, the service starts but doesn't get configured. We
decided that service startup, client tests, and service stop should
have unified base requirements.