### PR TITLE
HAve third party copy servers use their HTTP ports

### DIFF
--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -21,10 +21,12 @@ XROOTD_MACAROON_TXT = """\
 if named third-party-copy-1
 set HttpPort = 9001
 macaroons.secretkey /etc/xrootd/macaroon-secret-1
+xrd.port $(HttpPort)
 fi
 if named third-party-copy-2
 set HttpPort = 9002
 macaroons.secretkey /etc/xrootd/macaroon-secret-2
+xrd.port $(HttpPort)
 fi
 """
 


### PR DESCRIPTION
HAve third party copy servers use their HTTP ports as Xrootd ports to prevent port collision