### PR TITLE
Enable some other EL8 tests

### DIFF
--- a/osgtest/tests/test_580_gfal2util.py
+++ b/osgtest/tests/test_580_gfal2util.py
@@ -33,7 +33,7 @@ class TestGFAL2Util(osgunittest.OSGTestCase):
          file_copied = os.path.exists(TestGFAL2Util.__local_path)
          self.assert_(file_copied, 'Copied file missing')
 
-    @core.elrelease(7)
+    @core.elrelease(7,8)
     def test_02_copy_local_to_server_gfal2_util(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'gfal2-plugin-gridftp')
         self.skip_ok_unless(core.state['gridftp.running-server'], 'gridftp server not running')
@@ -44,7 +44,7 @@ class TestGFAL2Util(osgunittest.OSGTestCase):
         file_copied = os.path.exists(TestGFAL2Util.__remote_path)
         self.assert_(file_copied, 'Copied file missing')
 
-    @core.elrelease(7)
+    @core.elrelease(7,8)
     def test_03_remove_server_file_gfal2_util_gftp(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'gfal2-plugin-gridftp')
         self.skip_ok_unless(core.state['gridftp.running-server'], 'gridftp server not running')


### PR DESCRIPTION
(SOFTWARE-4073)

I think this plus the SLURM PR that just got merged are the only changes we need to make the tests marked EL7-only also run on EL8. In most places we used `>= 7` or already has `8` in the `@core.elrelease` decorator.