### PR TITLE
Make scitokens.conf file for tests

### DIFF
--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -106,10 +106,11 @@ CACHES_JSON_CONTENTS = """\
 ]
 """
 
-SCITOKENS_CONF_PATH = "/var/run/stash-cache-auth/scitokens.conf"
+ORIGIN_SCITOKENS_CONF_PATH = "/run/stash-origin-auth/scitokens.conf"
+CACHE_SCITOKENS_CONF_PATH = "/run/stash-cache-auth/scitokens.conf"
 SCITOKENS_CONF_CONTENTS = """\
 [Global]
-audience = unregistered_cache
+audience = unregistered
 
 [Issuer /unregistered]
 issuer = https://scitokens.org/unregistered
@@ -163,7 +164,9 @@ class TestStartStashCache(OSGTestCase):
                   os.path.join(PARAMS["OriginRootdir"], PARAMS["OriginAuthExport"].lstrip("/")),
                   os.path.join(PARAMS["CacheRootdir"], PARAMS["OriginDummyExport"].lstrip("/")),
                   os.path.dirname(CACHES_JSON_PATH),
-                  os.path.dirname(SCITOKENS_CONF_PATH)]:
+                  os.path.dirname(CACHE_SCITOKENS_CONF_PATH),
+                  os.path.dirname(ORIGIN_SCITOKENS_CONF_PATH),
+                  ]:
             files.safe_makedirs(d)
 
         core.system(["chown", "-R", "xrootd:xrootd", PARAMS["OriginRootdir"], PARAMS["CacheRootdir"]])
@@ -190,7 +193,8 @@ class TestStartStashCache(OSGTestCase):
             (CACHE_AUTHFILE_PATH, CACHE_AUTHFILE_CONTENTS),
             (CACHE_PUBLIC_AUTHFILE_PATH, CACHE_PUBLIC_AUTHFILE_CONTENTS),
             (CACHES_JSON_PATH, CACHES_JSON_CONTENTS),
-            (SCITOKENS_CONF_PATH, SCITOKENS_CONF_CONTENTS)
+            (CACHE_SCITOKENS_CONF_PATH, SCITOKENS_CONF_CONTENTS),
+            (ORIGIN_SCITOKENS_CONF_PATH, SCITOKENS_CONF_CONTENTS),
         ]:
             files.write(path, contents, owner=NAMESPACE, chmod=0o644)
             filelist.append(path)

--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -106,6 +106,16 @@ CACHES_JSON_CONTENTS = """\
 ]
 """
 
+SCITOKENS_CONF_PATH = "/var/run/stash-cache-auth/scitokens.conf"
+SCITOKENS_CONF_CONTENTS = """\
+[Global]
+audience = unregistered_cache
+
+[Issuer /unregistered]
+issuer = https://scitokens.org/unregistered
+base_path = /unregistered
+"""
+
 XROOTD_ORIGIN_CFG_PATH = "/etc/xrootd/xrootd-stash-origin.cfg"
 
 NAMESPACE = "stashcache"
@@ -152,7 +162,8 @@ class TestStartStashCache(OSGTestCase):
                   os.path.join(PARAMS["OriginRootdir"], PARAMS["OriginExport"].lstrip("/")),
                   os.path.join(PARAMS["OriginRootdir"], PARAMS["OriginAuthExport"].lstrip("/")),
                   os.path.join(PARAMS["CacheRootdir"], PARAMS["OriginDummyExport"].lstrip("/")),
-                  os.path.dirname(CACHES_JSON_PATH)]:
+                  os.path.dirname(CACHES_JSON_PATH),
+                  os.path.dirname(SCITOKENS_CONF_PATH)]:
             files.safe_makedirs(d)
 
         core.system(["chown", "-R", "xrootd:xrootd", PARAMS["OriginRootdir"], PARAMS["CacheRootdir"]])
@@ -178,7 +189,8 @@ class TestStartStashCache(OSGTestCase):
             (ORIGIN_PUBLIC_AUTHFILE_PATH, ORIGIN_PUBLIC_AUTHFILE_CONTENTS),
             (CACHE_AUTHFILE_PATH, CACHE_AUTHFILE_CONTENTS),
             (CACHE_PUBLIC_AUTHFILE_PATH, CACHE_PUBLIC_AUTHFILE_CONTENTS),
-            (CACHES_JSON_PATH, CACHES_JSON_CONTENTS)
+            (CACHES_JSON_PATH, CACHES_JSON_CONTENTS),
+            (SCITOKENS_CONF_PATH, SCITOKENS_CONF_CONTENTS)
         ]:
             files.write(path, contents, owner=NAMESPACE, chmod=0o644)
             filelist.append(path)

--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -109,9 +109,6 @@ CACHES_JSON_CONTENTS = """\
 ORIGIN_SCITOKENS_CONF_PATH = "/run/stash-origin-auth/scitokens.conf"
 CACHE_SCITOKENS_CONF_PATH = "/run/stash-cache-auth/scitokens.conf"
 SCITOKENS_CONF_CONTENTS = """\
-[Global]
-audience = unregistered
-
 [Issuer /unregistered]
 issuer = https://scitokens.org/unregistered
 base_path = /unregistered


### PR DESCRIPTION
Solves the same problem for osg-test that https://github.com/opensciencegrid/docker-xcache/pull/43 and https://github.com/opensciencegrid/docker-xcache/pull/44 solve for the containers.