### PR TITLE
HTCondor starts up too fast in 8.9.9 and we miss the schedd startup

### DIFF
--- a/osgtest/tests/test_190_condorce.py
+++ b/osgtest/tests/test_190_condorce.py
@@ -104,12 +104,13 @@ JOB_ROUTER_SCHEDD2_POOL=$(FULL_HOSTNAME):9618
         core.skip_ok_unless_installed('condor', 'htcondor-ce', 'htcondor-ce-client')
         core.config['condor-ce.collectorlog'] = condor.ce_config_val('COLLECTOR_LOG')
 
+        stat = core.get_stat(core.config['condor-ce.collectorlog'])
+
         if service.is_running('condor-ce'):
             core.state['condor-ce.schedd-ready'] = True
             self.skip_ok('already running')
 
         service.check_start('condor-ce', timeout=20)
 
-        stat = core.get_stat(core.config['condor-ce.collectorlog'])
         if condor.wait_for_daemon(core.config['condor-ce.collectorlog'], stat, 'Schedd', 300.0):
             core.state['condor-ce.schedd-ready'] = True


### PR DESCRIPTION
`core.get_stat` returns `None` if the file doesn't exist and `condor.wait_for_daemon` handles `None` stats by looking for the relevant sentinel starting at the beginning of the file. Things look pretty good here: https://osg-sw-submit.chtc.wisc.edu/tests/20201028-0817/results.html