### PR TITLE
Update Slurm tests for Slurm 20 (SOFTWARE-4446)

### DIFF
--- a/osgtest/library/mysql.py
+++ b/osgtest/library/mysql.py
@@ -4,35 +4,26 @@ import re
 from osgtest.library import core
 from osgtest.library import service
 
-def name():
-    if core.el_release() < 7:
-        return 'mysql'
-    else:
-        return 'mariadb'
-
-def daemon_name():
-    if core.el_release() < 7:
-        return 'mysqld'
-    else:
-        return 'mariadb'
+PACKAGE_NAME = 'mariadb'
+PORT = 3306
 
 def pidfile():
-    return os.path.join('/var/run', daemon_name(), daemon_name() + '.pid')
+    return os.path.join('/var/run', PACKAGE_NAME, PACKAGE_NAME + '.pid')
 
 def server_rpm():
-    return name() + '-server'
+    return PACKAGE_NAME + '-server'
 
 def client_rpm():
-    return name()
+    return PACKAGE_NAME
 
 def start():
-    service.check_start(daemon_name())
+    service.check_start(PACKAGE_NAME)
 
 def stop():
-    service.check_stop(daemon_name())
+    service.check_stop(PACKAGE_NAME)
 
 def is_running():
-    return service.is_running(daemon_name())
+    return service.is_running(PACKAGE_NAME)
 
 def _get_command(user='root', database=None):
     command = ['mysql', '-N', '-B', '--user=' + str(user)]

--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -30,18 +30,6 @@ class TestInstall(osgunittest.OSGTestCase):
         fail_msg = ''
         pkg_repo_dict = OrderedDict((x, core.options.extrarepos) for x in core.options.packages)
 
-        # HACK: Install Slurm and osg-tested-internal out of development-like repos.
-        # SOFTWARE-1733 may one day give us a generalized solution.
-        if core.osg_release() > '3.4':
-            dev_repo = ['devops-itb']
-            if 'osg-tested-internal' in pkg_repo_dict:
-                pkg_repo_dict['osg-tested-internal'] += dev_repo
-        else:
-            dev_repo = ['osg-development']
-
-        if 'osg-tested-internal' in pkg_repo_dict or 'slurm' in pkg_repo_dict:
-            pkg_repo_dict.update(dict((x, core.options.extrarepos + dev_repo) for x in core.SLURM_PACKAGES))
-
         # HACK: Install x509-scitokens-issuer-client out of development (SOFTWARE-3649)
         x509_scitokens_issuer_packages = ['xrootd-scitokens', 'osg-tested-internal']
         for pkg in x509_scitokens_issuer_packages:

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -107,9 +107,9 @@ class TestStartSlurm(osgunittest.OSGTestCase):
                             'slurmdb user permissions')
         mysql.check_execute("flush privileges;", 'reload privileges')
 
-        db_config_vals = {'name':core.config['slurmdbd.name'],
-                          'user':core.config['slurmdbd.user'].split('\'')[1],
-                          'pass':core.options.password}
+        db_config_vals = {'name': core.config['slurmdbd.name'],
+                          'user': core.config['slurmdbd.user'].split('\'')[1],
+                          'pass': core.options.password}
         files.write(core.config['slurmdbd.config'],
                     SLURMDBD_CONFIG % db_config_vals,
                     owner='slurm',
@@ -151,4 +151,3 @@ class TestStartSlurm(osgunittest.OSGTestCase):
                           60.0)
         command = ['scontrol', 'update', 'nodename=%s' % SHORT_HOSTNAME, 'state=idle']
         core.check_system(command, 'enable slurm node')
-

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -22,7 +22,6 @@ StoragePort={port}
 """
 
 SLURM_CONFIG = """AccountingStorageHost=localhost
-AccountingStorageLoc=/tmp/slurm_job_accounting.txt
 AccountingStorageType=accounting_storage/slurmdbd
 AuthType=auth/munge
 ClusterName={cluster}

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -15,25 +15,25 @@ DbdHost=localhost
 DebugLevel=debug5
 LogFile=/var/log/slurm/slurmdbd.log
 StorageType=accounting_storage/mysql
-StorageLoc=%(name)s
-StorageUser=%(user)s
-StoragePass=%(pass)s
+StorageLoc={name}
+StorageUser={user}
+StoragePass={password}
 """
 
 SLURM_CONFIG = """AccountingStorageHost=localhost
 AccountingStorageLoc=/tmp/slurm_job_accounting.txt
 AccountingStorageType=accounting_storage/slurmdbd
 AuthType=auth/munge
-ClusterName=%(cluster)s
-ControlMachine=%(short_hostname)s
+ClusterName={cluster}
+ControlMachine={short_hostname}
 JobAcctGatherType=jobacct_gather/linux
 KillWait=30
-NodeName=%(short_hostname)s Procs=1 RealMemory=128 State=UNKNOWN
-PartitionName=debug Nodes=%(short_hostname)s Default=YES MaxTime=INFINITE State=UP
+NodeName={short_hostname} Procs=1 RealMemory=128 State=UNKNOWN
+PartitionName=debug Nodes={short_hostname} Default=YES MaxTime=INFINITE State=UP
 ReturnToService=2
 SlurmctldDebug=debug5
 SlurmctldTimeout=300
-SlurmctldLogFile=%(ctld_log)s
+SlurmctldLogFile={ctld_log}
 SlurmdLogFile=/var/log/slurm/slurm.log
 SlurmdDebug=debug5
 StateSaveLocation=/var/spool/slurmd
@@ -65,7 +65,9 @@ class TestStartSlurm(osgunittest.OSGTestCase):
         core.config['slurm.config-dir'] = '/etc/slurm'
         core.config['slurm.config'] = os.path.join(core.config['slurm.config-dir'], 'slurm.conf')
         files.write(core.config['slurm.config'],
-                    SLURM_CONFIG % {'short_hostname': SHORT_HOSTNAME, 'cluster': CLUSTER_NAME, 'ctld_log': CTLD_LOG},
+                    SLURM_CONFIG.format(short_hostname=SHORT_HOSTNAME,
+                                        cluster=CLUSTER_NAME,
+                                        ctld_log=CTLD_LOG),
                     owner='slurm',
                     chmod=0o644)
         core.config['cgroup.config'] = os.path.join(core.config['slurm.config-dir'], 'cgroup.conf')
@@ -102,11 +104,10 @@ class TestStartSlurm(osgunittest.OSGTestCase):
                             'slurmdb user permissions')
         mysql.check_execute("flush privileges;", 'reload privileges')
 
-        db_config_vals = {'name': core.config['slurmdbd.name'],
-                          'user': core.config['slurmdbd.user'].split('\'')[1],
-                          'pass': core.options.password}
         files.write(core.config['slurmdbd.config'],
-                    SLURMDBD_CONFIG % db_config_vals,
+                    SLURMDBD_CONFIG.format(name=core.config['slurmdbd.name'],
+                                           user=core.config['slurmdbd.user'].split('\'')[1],
+                                           password=core.options.password,),
                     owner='slurm',
                     chmod=0o644)
         service.check_start('slurmdbd')

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -116,24 +116,18 @@ class TestStartSlurm(osgunittest.OSGTestCase):
         core.check_system(command, 'add slurm cluster')
 
     def test_03_start_slurm(self):
-        core.config['slurm.service-name'] = 'slurm'
-        if core.el_release() >= 7:
-            core.config['slurm.service-name'] += 'd'
-            core.config['slurm.ctld-service-name'] = 'slurmctld'
+        core.config['slurm.service-name'] = 'slurmd'
+        core.config['slurm.ctld-service-name'] = 'slurmctld'
         core.state['%s.started-service' % core.config['slurm.service-name']] = False
         self.slurm_reqs()
         self.skip_ok_if(service.is_running(core.config['slurm.service-name']), 'slurm already running')
 
         stat = core.get_stat(CTLD_LOG)
 
-        if core.el_release() >= 7:
-            # slurmctld is handled by /etc/init.d/slurm on EL6
-            command = ['slurmctld']
-            core.check_system(command, 'enable slurmctld')
-            service.check_start(core.config['slurm.service-name'])
-            service.check_start(core.config['slurm.ctld-service-name'])
-        else:
-            service.check_start(core.config['slurm.service-name'])
+        command = ['slurmctld']
+        core.check_system(command, 'enable slurmctld')
+        service.check_start(core.config['slurm.service-name'])
+        service.check_start(core.config['slurm.ctld-service-name'])
 
         core.monitor_file(CTLD_LOG,
                           stat,

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -18,6 +18,7 @@ StorageType=accounting_storage/mysql
 StorageLoc={name}
 StorageUser={user}
 StoragePass={password}
+StoragePort={port}
 """
 
 SLURM_CONFIG = """AccountingStorageHost=localhost
@@ -106,7 +107,8 @@ class TestStartSlurm(osgunittest.OSGTestCase):
         files.write(core.config['slurmdbd.config'],
                     SLURMDBD_CONFIG.format(name=core.config['slurmdbd.name'],
                                            user=core.config['slurmdbd.user'].split('\'')[1],
-                                           password=core.options.password,),
+                                           password=core.options.password,
+                                           port=mysql.PORT),
                     owner='slurm',
                     chmod=0o644)
         service.check_start('slurmdbd')

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -64,10 +64,7 @@ class TestStartSlurm(osgunittest.OSGTestCase):
 
     def test_01_slurm_config(self):
         self.slurm_reqs()
-        if core.PackageVersion('slurm') >= '19.05.2':
-            core.config['slurm.config-dir'] = '/etc'
-        else:
-            core.config['slurm.config-dir'] = '/etc/slurm'
+        core.config['slurm.config-dir'] = '/etc/slurm'
         core.config['slurm.config'] = os.path.join(core.config['slurm.config-dir'], 'slurm.conf')
         files.write(core.config['slurm.config'],
                     SLURM_CONFIG % {'short_hostname': SHORT_HOSTNAME, 'cluster': CLUSTER_NAME, 'ctld_log': CTLD_LOG},

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -89,7 +89,6 @@ class TestStartSlurm(osgunittest.OSGTestCase):
     def test_02_start_slurmdbd(self):
         core.state['slurmdbd.started-service'] = False
         self.slurm_reqs()
-        core.skip_ok_unless_installed('slurm-slurmdbd')
         self.skip_bad_unless(mysql.is_running(), 'slurmdbd requires mysql')
         core.config['slurmdbd.config'] = os.path.join(core.config['slurm.config-dir'], 'slurmdbd.conf')
         core.config['slurmdbd.user'] = "'osg-test-slurm'@'localhost'"

--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -12,7 +12,6 @@ SHORT_HOSTNAME = core.get_hostname().split('.')[0]
 
 SLURMDBD_CONFIG = """AuthType=auth/munge
 DbdHost=localhost
-SlurmUser=slurm
 DebugLevel=debug5
 LogFile=/var/log/slurm/slurmdbd.log
 StorageType=accounting_storage/mysql
@@ -32,7 +31,6 @@ KillWait=30
 NodeName=%(short_hostname)s Procs=1 RealMemory=128 State=UNKNOWN
 PartitionName=debug Nodes=%(short_hostname)s Default=YES MaxTime=INFINITE State=UP
 ReturnToService=2
-SlurmUser=slurm
 SlurmctldDebug=debug5
 SlurmctldTimeout=300
 SlurmctldLogFile=%(ctld_log)s

--- a/osgtest/tests/test_740_slurm.py
+++ b/osgtest/tests/test_740_slurm.py
@@ -13,8 +13,7 @@ class TestStopSlurm(osgunittest.OSGTestCase):
         self.slurm_reqs()
         self.skip_ok_unless(core.state['%s.started-service' % core.config['slurm.service-name']], 'did not start slurm')
         service.check_stop(core.config['slurm.service-name']) # service requires config so we stop it first
-        if core.el_release() >= 7:
-            service.check_stop(core.config['slurm.ctld-service-name'])
+        service.check_stop(core.config['slurm.ctld-service-name'])
         files.restore(core.config['slurm.config'], 'slurm')
         files.restore(core.config['cgroup.config'], 'slurm')
         files.restore(core.config['cgroup_allowed_devices_file.conf'], 'slurm')


### PR DESCRIPTION
Test results here: https://osg-sw-submit.chtc.wisc.edu/tests/20210325-1148/packages.html. 3.6 `slurm_trace` tests fail because the 3.6 blahp is broken but this otherwise fixes all the other Slurm startup failures we're seeing in the nightlies