### PR TITLE
Add new condor mapfile syntax

### DIFF
--- a/osgtest/tests/test_190_condorce.py
+++ b/osgtest/tests/test_190_condorce.py
@@ -47,7 +47,9 @@ QUEUE_SUPER_USER_MAY_IMPERSONATE = .*"""
         # Write the mapfile to the admin mapfile directory with the regex format for the issuer
         # required by 'CERTIFICATE_MAPFILE_ASSUME_HASH_KEYS = True'
         # https://github.com/htcondor/htcondor-ce/pull/425
-        if condorce_version >= '5.1.0':
+        # We apply this to HTCondor-CE 5 as a whole for the benefit of the HTCondor-CE CI tests
+        # This is ok even though these changes will only make it into 5.1.0 because 5.0.0 will not be released
+        if condorce_version >= '5.0.0':
             match_str = r'/https:\/\/demo.scitokens.org,.*/'
             core.config['condor-ce.mapfile'] = '/etc/condor-ce/mapfiles.d/01-osg-test.conf'
         else:


### PR DESCRIPTION
In HTCondor-CE 5.1.0 we're going to be forcing users to wrap the 2nd field in the mapfile with `/` if they want them to be regex (added in https://github.com/htcondor/htcondor-ce/pull/425) and this has been causing our HTCondor-CE EL7 osg CI tests to fail. This fixes that failure (run here: https://github.com/brianhlin/htcondor-ce/actions/runs/712664940).

N.B. the EL8 osg failure seems to be real issue where the client seems to be segfaulting