### PR TITLE
Use new config for newer versions of xrootd-multiuser

### DIFF
--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -110,7 +110,11 @@ class TestStartXrootd(osgunittest.OSGTestCase):
 
     def test_03_configure_multiuser(self):
         core.skip_ok_unless_installed('xrootd-multiuser', 'globus-proxy-utils', by_dependency=True)
-        xrootd_multiuser_conf = "xrootd.fslib libXrdMultiuser.so default"
+        if core.PackageVersion("xrootd-multiuser") < "1.0.0-0":
+            xrootd_multiuser_conf = "xrootd.fslib libXrdMultiuser.so default"
+        else:
+            xrootd_multiuser_conf = "ofs.osslib ++ libXrdMultiuser.so\n" \
+                                    "ofs.ckslib ++ libXrdMultiuser.so"
         files.append(core.config['xrootd.config'], xrootd_multiuser_conf, owner='xrootd', backup=False)
         core.config['xrootd.multiuser'] = True
 


### PR DESCRIPTION
(SOFTWARE-4599)

Example tests are part of https://osg-sw-submit.chtc.wisc.edu/tests/20210505-1714/packages.html (see the "XRootD" package set).
