### PR TITLE
Revert "The testing should include multistream"

### DIFF
--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -50,8 +50,7 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
         command = ('curl', '-A', 'Test', "-vk", "-X", "COPY",
                    '-H', "Authorization: Bearer %s" % core.config['xrootd.tpc.macaroon-1'],
                    '-H', "Source: %s" % core.config['xrootd.tpc.url-1'], 
-                   '-H', 'Overwrite: T',
-                   '-H', 'X-Number-Of-Streams: 2',
+                   '-H', 'Overwrite: T', 
                    '-H', 'Copy-Header:  Authorization: Bearer %s'% core.config['xrootd.tpc.macaroon-2'],
                    core.config['xrootd.tpc.url-2'])
         status, stdout, stderr = core.system(command, user=True)


### PR DESCRIPTION
This has been broken with XRootD 5 for a long time, but multistream TPC is not a common OSG use case

This reverts commit c4d10e044fd1a56a144cb2085c7b19baef827cf9.