### PR TITLE
Special case: enable mod_auth_oidc module for htcondor-ce-collector on EL8

### DIFF
--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -37,6 +37,11 @@ class TestInstall(osgunittest.OSGTestCase):
                 pkg_repo_dict["x509-scitokens-issuer-client"] = ["osg-development"]
                 break
 
+        # Special case: htcondor-ce-collector on EL8 needs mod_auth_oidc, only avaiable in a module
+        if "htcondor-ce-collector" in pkg_repo_dict:
+            if core.el_release() > 7:
+                core.check_system(["dnf", "-y", "module", "enable", "mod_auth_openidc"], "Enable mod_auth_openidc module")
+
         for pkg, repos in pkg_repo_dict.items():
             # Do not try to re-install packages
             if core.rpm_is_installed(pkg):


### PR DESCRIPTION
SOFTWARE-4607.

Test results: https://osg-sw-submit.chtc.wisc.edu/tests/20210608-1549/packages.html
(the 3.6 build doesn't have the patch for [HTCONDOR-512](https://opensciencegrid.atlassian.net/browse/HTCONDOR-512) but actual installation succeeded)