### PR TITLE
Fix KeyError in TPC tests if macaroon creation failed (SOFTWARE-4604)

### DIFF
--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -16,11 +16,10 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_create_macaroons(self):
-        core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
-        self.skip_bad_unless(core.state['proxy.valid'], 'requires a proxy cert')
         core.config['xrootd.tpc.macaroon-1'] = None
         core.config['xrootd.tpc.macaroon-2'] = None
-        
+        core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
+        self.skip_bad_unless(core.state['proxy.valid'], 'requires a proxy cert')
         uid = pwd.getpwnam(core.options.username)[2]
         usercert = '/tmp/x509up_u%d' % uid
         userkey = '/tmp/x509up_u%d' % uid
@@ -29,7 +28,7 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
         command = ('macaroon-init', core.config['xrootd.tpc.url-1'], '20', 'ALL')
 
         status, stdout, stderr = core.system(command, user=True)
-        fail = core.diagnose('Obtain Macaroon one',
+        fail = core.diagnose('Obtain Macaroon 1',
                              command, status, stdout, stderr)
         self.assertEqual(status, 0, fail)
         core.config['xrootd.tpc.macaroon-1'] = stdout.strip()
@@ -37,15 +36,15 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
         core.config['xrootd.tpc.url-2'] = "https://" + core.get_hostname() + ":9002" + "/tmp/test_gridftp_data_tpc.txt".strip()
         command = ('macaroon-init', core.config['xrootd.tpc.url-2'], '20', 'ALL')
         status, stdout, stderr = core.system(command, user=True)
-        fail = core.diagnose('Obtain Macaroon number two',
+        fail = core.diagnose('Obtain Macaroon 2',
                              command, status, stdout, stderr)
         self.assertEqual(status, 0, fail)
         core.config['xrootd.tpc.macaroon-2'] = stdout.strip()
         
     def test_02_initate_tpc(self):
         core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
-        self.skip_bad_if(core.config['xrootd.tpc.macaroon-1'] is None, 'Macaroon creation failed earlier')
-        self.skip_bad_if(core.config['xrootd.tpc.macaroon-2'] is None, 'Macaroon creation failed earlier')
+        self.skip_bad_if(core.config['xrootd.tpc.macaroon-1'] is None, 'Macaroon 1 creation failed earlier')
+        self.skip_bad_if(core.config['xrootd.tpc.macaroon-2'] is None, 'Macaroon 2 creation failed earlier')
         headers = {}
         command = ('curl', '-A', 'Test', "-vk", "-X", "COPY",
                    '-H', "Authorization: Bearer %s" % core.config['xrootd.tpc.macaroon-1'],


### PR DESCRIPTION
Note: this doesn't solve any test failures, just gives us a better error message.
(SOFTWARE-4604)