### PR TITLE
Turn core.state into a defaultdict with values deafulting to False

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -16,6 +16,8 @@ import traceback
 import socket
 import signal
 
+from collections import defaultdict as defaultdict
+
 import rpm
 try:
     from rpmUtils.miscutils import stringToVersion
@@ -41,12 +43,11 @@ config['user.home'] = '/var/home'
 config['system.mapfile'] = '/etc/grid-security/grid-mapfile'
 
 # Global state dictionary.  Other modules may add, read, change, and delete the
-# keys stored herein.  At the moment, no checking is done on its contents, so
-# individual tests should be careful about using it.  The recommendation is to
-# prefix each key with "COMP.", where "COMP" is a short lowercase string that
-# indicates which component the test belongs to, or "general." for truly cross-
-# cutting objects.
-state = {'proxy.valid': False}  # TODO: Drop 'proxy.valid' after we drop support for OSG 3.5
+# keys stored herein. Tests can safely check for keys in this dict, regardless
+# of their existence (default: False).  The recommendation is to prefix each key
+# with "COMP.", where "COMP" is a short lowercase string that indicates which
+# component the test belongs to, or "general." for truly cross- cutting objects.
+state = defaultdict(bool)
 
 class DummyClass(object):
     """A class that ignores all function calls; useful for testing"""

--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -6,11 +6,6 @@ import os
 import os.path
 import pwd
 import re
-import rpm
-try:
-    from rpmUtils.miscutils import stringToVersion
-except ImportError:
-    from osgtest.vendor.miscutils import stringToVersion
 import shutil
 import stat
 import subprocess
@@ -20,6 +15,12 @@ import time
 import traceback
 import socket
 import signal
+
+import rpm
+try:
+    from rpmUtils.miscutils import stringToVersion
+except ImportError:
+    from osgtest.vendor.miscutils import stringToVersion
 try:
     from shlex import quote as shell_quote
 except ImportError:


### PR DESCRIPTION
The only state keys that aren't bools are the ones used for https://github.com/opensciencegrid/osg-test/blob/master/osgtest/tests/special_install.py