### PR TITLE
Use BEARER_TOKEN_FILE env var to specify the token path

### DIFF
--- a/osgtest/tests/test_410_jobs.py
+++ b/osgtest/tests/test_410_jobs.py
@@ -71,7 +71,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
         self.skip_bad_unless(core.state['proxy.valid'] or core.state['token.condor_write_created'],
                              'requires a scitoken or a proxy')
 
-        command = ['condor_ce_run', '-r', '%s:9619' % core.get_hostname(), '/bin/env']
+        command = ['condor_ce_run', '--debug', '-r', '%s:9619' % core.get_hostname(), '/bin/env']
 
         if core.state['token.condor_write_created']:
             # FIXME: After HTCONDOR-636 is released (targeted for HTCondor-CE 5.1.2),

--- a/osgtest/tests/test_410_jobs.py
+++ b/osgtest/tests/test_410_jobs.py
@@ -17,10 +17,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
                     'BEARER_TOKEN_FILE')
 
         for env_var in env_vars:
-            try:
-                os.environ.pop(env_var)
-            except KeyError:
-                pass
+            os.environ.pop(env_var, None)
 
     def verify_job_environment(self, output):
         expected_env = {'JOB_ENV': 'vdt',

--- a/osgtest/tests/test_410_jobs.py
+++ b/osgtest/tests/test_410_jobs.py
@@ -16,8 +16,7 @@ class TestRunJobs(osgunittest.OSGTestCase):
         env_vars = ('_condor_SCITOKENS_FILE',
                     'BEARER_TOKEN_FILE')
 
-        for env_var in env_vars:
-            os.environ.pop(env_var, None)
+        [ os.environ.pop(env_var, None) for env_var in env_vars ]
 
     def verify_job_environment(self, output):
         expected_env = {'JOB_ENV': 'vdt',

--- a/osgtest/tests/test_550_condorce.py
+++ b/osgtest/tests/test_550_condorce.py
@@ -24,10 +24,24 @@ class TestCondorCE(osgunittest.OSGTestCase):
 
         self.command = []
         if core.state['token.condor_write_created']:
-            self.command = [f"_condor_SCITOKENS_FILE={core.config['token.condor_write']}"]
+            # FIXME: After HTCONDOR-636 is released (targeted for HTCondor-CE 5.1.2),
+            # we can stop setting _condor_SCITOKENS_FILE
+            for token_var in ('_condor_SCITOKENS_FILE',
+                              'BEARER_TOKEN_FILE'):
+                os.environ[token_var] = core.config['token.condor_write']
+        else:
+            core.log_message('condor WRITE token not found; skipping SCITOKENS auth')
 
     def tearDown(self):
-        os.environ.pop('_condor_SEC_CLIENT_AUTHENTICATION_METHODS')
+        env_vars = ('_condor_SEC_CLIENT_AUTHENTICATION_METHODS',
+                    '_condor_SCITOKENS_FILE',
+                    'BEARER_TOKEN_FILE')
+
+        for env_var in env_vars:
+            try:
+                os.environ.pop(env_var)
+            except KeyError:
+                pass
 
     def check_write_creds(self):
         """Check for credentials necessary for HTCondor-CE WRITE

--- a/osgtest/tests/test_550_condorce.py
+++ b/osgtest/tests/test_550_condorce.py
@@ -38,10 +38,7 @@ class TestCondorCE(osgunittest.OSGTestCase):
                     'BEARER_TOKEN_FILE')
 
         for env_var in env_vars:
-            try:
-                os.environ.pop(env_var)
-            except KeyError:
-                pass
+            os.environ.pop(env_var, None)
 
     def check_write_creds(self):
         """Check for credentials necessary for HTCondor-CE WRITE


### PR DESCRIPTION
Token discovery details: https://zenodo.org/record/3937438. Support was added for this to `condor_submit` in 9.0.2 and is expected in 9.1.3. I'm working on making use of this in `condor_ce_run` and adding token discovery to `condor_ce_trace`
