### PR TITLE
Don't print output for some system calls

### DIFF
--- a/osgtest/library/service.py
+++ b/osgtest/library/service.py
@@ -90,7 +90,7 @@ def status(service_name):
     else:
         command = ('service', service_name, 'status')
 
-    status_rc, _, _ = core.system(command)
+    status_rc, _, _ = core.system(command, quiet=True)
     return status_rc
 
 def check_status(service_name, expected_status, timeout=10, log_to_check = None):


### PR DESCRIPTION
Compare https://osg-sw-submit.chtc.wisc.edu/tests/20210903-2358/results.html
to a nightly run https://osg-sw-submit.chtc.wisc.edu/tests/20210904-0423/results.html

doesn't look much different in the raw logs but if you're doing a manual run with --df (to dump output into a separate file) or are looking at the output with osg-test-log-viewer, it's nice not to have it cluttered up with a ton of "rpm --query" and "systemctl is-active" calls.