### PR TITLE
Account for new gfal2-util package split (SOFTWARE-4825)

### DIFF
--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -139,8 +139,9 @@ class TestStashCache(OSGTestCase):
         self.assert_(checksum_match, 'Origin and file downloaded via cache have the same contents')
 
     def test_08_https_fetch_from_auth_cache(self):
-        core.skip_ok_unless_installed('globus-proxy-utils', 'gfal2-plugin-http', 'gfal2-util', 
+        core.skip_ok_unless_installed('globus-proxy-utils', 'gfal2-plugin-http', 'gfal2-util-scripts',
                                       'gfal2-plugin-file', by_dependency=True)
+        core.skip_ok_unless_one_installed('python2-gfal2-util', 'python3-gfal2-util')
         self.skip_bad_unless(core.state['proxy.valid'], 'requires a proxy cert')
         name, contents = self.testfiles[3]
         path = os.path.join(getcfg("OriginAuthExport"), name)

--- a/osgtest/tests/test_580_gfal2util.py
+++ b/osgtest/tests/test_580_gfal2util.py
@@ -13,7 +13,8 @@ class TestGFAL2Util(osgunittest.OSGTestCase):
 
     def setUp(self):
         self.skip_ok_unless(core.state['proxy.valid'] or core.state['voms.got-proxy'], "No proxy")
-        core.skip_ok_unless_installed('gfal2-util', 'gfal2-plugin-file')
+        core.skip_ok_unless_installed('gfal2-util-scripts', 'gfal2-plugin-file')
+        core.skip_ok_unless_one_installed('python2-gfal2-util', 'python3-gfal2-util')
 
     def get_gftp_url_base(self):
         return 'gsiftp://%s/' % (TestGFAL2Util.__hostname)


### PR DESCRIPTION
Test results here https://osg-sw-submit.chtc.wisc.edu/tests/20210922-0855/packages.html. EL8 failures are expected because only `python3-gfal2-util` is available on EL8 and it doesn't provide `gfal2-util`