### PR TITLE
Add environ_context, preserve_and_remove, and put test user uid/gid/home dir into core.state

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -1,6 +1,7 @@
 """Support and convenience functions for tests."""
 from __future__ import print_function
 
+import contextlib
 import errno
 import os
 import os.path
@@ -810,3 +811,21 @@ def to_bytes(strlike, encoding="latin-1", errors="backslashreplace"):
     if not isinstance(strlike, bytes):
         return strlike.encode(encoding, errors)
     return strlike
+
+
+@contextlib.contextmanager
+def environ_context(key, value):
+    """A context manager for running a block with an environment variable set,
+    restoring the original afterward.
+
+    """
+    old_value = os.environ.pop(key, None)
+    if value is not None:
+        os.environ[key] = value
+    try:
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = old_value

--- a/osgtest/tests/special_user.py
+++ b/osgtest/tests/special_user.py
@@ -83,6 +83,10 @@ class TestUser(osgunittest.OSGTestCase):
         self.assert_(os.path.isdir(user.pw_dir),
                      "User '%s' missing a home directory at '%s'" % (core.options.username, user.pw_dir))
 
+        core.state['user.uid'] = user.pw_uid
+        core.state['user.gid'] = user.pw_gid
+        core.state['user.home'] = user.pw_dir
+
         core.state['user.verified'] = True
 
     def test_03_generate_user_cert(self):


### PR DESCRIPTION
Some miscellaneous useful stuff from my xrootd branch.

- environ_context: a context manager (with statement) for setting an environment variable and restoring it afterward
- preserve_and_remove: back up a file and then delete it
- add 'user.uid', 'user.gid', and 'user.home' to core.state so you don't have to look it up later
