### PR TITLE
XRootD for 3.6 tests

### DIFF
--- a/osgtest/library/files.py
+++ b/osgtest/library/files.py
@@ -195,10 +195,12 @@ def append(path, contents, force=False, owner=None, backup=True):
     write(path, new_contents, backup=False)
 
 
-def restore(path, owner):
+def restore(path, owner, ignore_missing=False):
     """Restores the path to its state prior to being written by its owner."""
     backup_id = (path, owner)
     if backup_id not in _backups:
+        if ignore_missing:
+            return
         raise ValueError("No backup of '%s' for '%s'" % (path, owner))
 
     if os.path.exists(path):

--- a/osgtest/library/osgunittest.py
+++ b/osgtest/library/osgunittest.py
@@ -8,6 +8,7 @@ standard Python unittest library have been made:
 # quiet all the 'Method could be a function' or 'Invalid name' warnings;
 # I'm following the conventions unittest set.
 # pylint: disable=R0201,C0103
+import re
 import sys
 import unittest
 import time
@@ -137,6 +138,14 @@ class OSGTestCase(unittest.TestCase):
         else:
             fullmessage = aftermessage
         self.assertEqual(actual, expected, fullmessage)
+
+    def assertRegexInList(self, test_list, regex, message=None):
+        """Assert that a member of the list matches the regex (using re.search())"""
+        self.assertTrue(any(re.search(regex, line) for line in test_list), message)
+
+    def assertRegexNotInList(self, test_list, regex, message=None):
+        """Assert that no member of the list matches the regex (using re.search())"""
+        self.assertFalse(any(re.search(regex, line) for line in test_list), message)
 
     # This is mostly a copy of the method from unittest in python 2.4.
     # There is some code here to test if the 'result' object accepts 'skips',

--- a/osgtest/library/xrootd.py
+++ b/osgtest/library/xrootd.py
@@ -1,0 +1,34 @@
+"""Utilities for dealing with XRootD"""
+import os
+
+from osgtest.library import core
+
+
+ROOTDIR = f"/tmp/xrootd-osgtest-{os.getpid()}"
+
+
+def cconfig(instance, executable="xrootd", raw=True, quiet=True):
+    """Return the a config dump of an xrootd instance using cconfig"""
+    # Using shell=True because cconfig prints output into stderr and there's a
+    # bug in core.__run_command()'s stderr handling.
+    ret, output, _ = core.system(f"cconfig -x {executable} -n {instance} -c /etc/xrootd/xrootd-{instance}.cfg 2>&1", shell=True, quiet=quiet)
+
+    if raw:
+        if ret != 0:
+            return ""
+        return output
+    else:
+        if ret != 0:
+            return []
+        return [line for line in output.splitlines() if not line.startswith("Config continuing with file ")]
+
+
+def dump_log(lines, instance, executable="xrootd"):
+    """Dump the last `lines` lines of an xrootd log file for the given instance."""
+    # Using tail(1) here because the executable log is actually a nice place
+    # to put the output.
+    core.system(["tail", "-n", str(lines), f"/var/log/xrootd/{instance}/{executable}.log"])
+
+
+def logfile(instance, executable="xrootd"):
+    return f"/var/log/xrootd/{instance}/{executable}.log"

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -99,17 +99,20 @@ class TestStartXrootd(osgunittest.OSGTestCase):
     @core.osgrelease(3.5)
     def test_04_configure_hdfs(self):
         core.skip_ok_unless_installed('xrootd-hdfs')
-        hdfs_config = "ofs.osslib /usr/lib64/libXrdHdfs.so"
+        hdfs_config = "ofs.osslib /usr/lib64/libXrdHdfs.so\n"
         files.append(core.config['xrootd.config'], hdfs_config, backup=False)
 
     def test_05_configure_multiuser(self):
-        core.skip_ok_unless_installed('xrootd-multiuser', 'globus-proxy-utils', by_dependency=True)
+        core.skip_ok_unless_installed('xrootd-multiuser', by_dependency=True)
         if core.PackageVersion("xrootd-multiuser") < "1.0.0-0":
-            xrootd_multiuser_conf = "xrootd.fslib libXrdMultiuser.so default"
+            xrootd_multiuser_conf = "xrootd.fslib libXrdMultiuser.so default\n"
         else:
             xrootd_multiuser_conf = "ofs.osslib ++ libXrdMultiuser.so\n" \
-                                    "ofs.ckslib ++ libXrdMultiuser.so"
-        files.append(core.config['xrootd.config'], xrootd_multiuser_conf, owner='xrootd', backup=False)
+                                    "ofs.ckslib ++ libXrdMultiuser.so\n"
+        if os.path.exists("/etc/xrootd/config.d/60-osg-multiuser.cfg"):
+            core.log_message("Not adding XRootD multiuser config, already exists")
+        else:
+            files.append(core.config['xrootd.config'], xrootd_multiuser_conf, owner='xrootd', backup=False)
         core.config['xrootd.multiuser'] = True
 
     def test_06_configure_scitokens(self):

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -23,6 +23,12 @@ u = /tmp/@=/ a
 u xrootd /tmp a
 """
 
+XROOTD_LOGGING_CFG_TEXT = """\
+xrootd.trace all
+xrd.trace all -sched
+ofs.trace all
+http.trace all
+"""
 
 
 
@@ -42,6 +48,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'
         # rootdir and resourcename needs to be set early for the default osg-xrootd config
         core.config['xrootd.config'] = '/etc/xrootd/config.d/10-osg-test.cfg'
+        core.config['xrootd.logging-config'] = '/etc/xrootd/config.d/99-logging.cfg'
         core.config['xrootd.service-defaults'] = '/etc/sysconfig/xrootd'
         core.config['xrootd.multiuser'] = False
         core.state['xrootd.started-server'] = False
@@ -62,6 +69,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.install_cert('certs.xrootdcert', 'certs.hostcert', 'xrootd', 0o644)
         core.install_cert('certs.xrootdkey', 'certs.hostkey', 'xrootd', 0o400)
 
+        files.write(core.config['xrootd.logging-config'], XROOTD_LOGGING_CFG_TEXT, owner='xrootd', backup=True, chmod=0o644)
         files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True, chmod=0o644)
 
         authfile = '/etc/xrootd/auth_file'

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -24,7 +24,7 @@ set rootdir = {xrootd.ROOTDIR}
 set resourcename = OSG_TEST_XROOTD_STANDALONE
 xrd.tls /etc/grid-security/xrd/xrdcert.pem /etc/grid-security/xrd/xrdkey.pem
 xrd.tlsca noverify
-acc.authdb /etc/xrootd/auth_file
+acc.authdb /etc/xrootd/Authfile
 ofs.authorize
 """
 
@@ -104,7 +104,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         files.write(core.config['xrootd.logging-config'], XROOTD_LOGGING_CFG_TEXT, owner='xrootd', backup=True, chmod=0o644)
         files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True, chmod=0o644)
 
-        authfile = '/etc/xrootd/auth_file'
+        authfile = '/etc/xrootd/Authfile'
         files.write(authfile, AUTHFILE_TEXT, owner="xrootd", chown=(xrootd_user.pw_uid, xrootd_user.pw_gid), chmod=0o644)
         try:
             shutil.rmtree(xrootd.ROOTDIR)

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -17,8 +17,8 @@ http.header2cgi Authorization authz
 """
 
 # XRootD configuration necessary for osg-xrootd-standalone
-STANDALONE_XROOTD_CFG_TEXT = """\
-set rootdir = /
+STANDALONE_XROOTD_CFG_TEXT = f"""\
+set rootdir = {xrootd.ROOTDIR}
 set resourcename = OSG_TEST_XROOTD_STANDALONE
 xrd.tls /etc/grid-security/xrd/xrdcert.pem /etc/grid-security/xrd/xrdkey.pem
 xrd.tlsca noverify

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -86,6 +86,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
             core.config['xrootd.security'] = "GSI"
 
         else:  # 3.6+
+        # FIXME: remove else after https://opensciencegrid.atlassian.net/browse/SOFTWARE-4858 is released
             core.skip_ok_unless_installed("xrootd-scitokens")
             core.config['xrootd.security'] = "SCITOKENS"
 

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -3,30 +3,18 @@ import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.xrootd as xrootd
 
 
-XROOTD_CFG_TEXT = """\
-cms.space min 2g 5g
-xrootd.seclib libXrdSec.so
-sec.protocol /usr/lib64 gsi -certdir:/etc/grid-security/certificates \
-    -cert:/etc/grid-security/xrd/xrdcert.pem \
-    -key:/etc/grid-security/xrd/xrdkey.pem \
-    -crl:3 \
-    --gmapopt:10 \
-    --gmapto:0 \
-    %s
-acc.authdb /etc/xrootd/auth_file
-ofs.authorize
-xrd.tls /etc/grid-security/xrd/xrdcert.pem /etc/grid-security/xrd/xrdkey.pem
-xrd.tlsca noverify
-"""
 
-# XRootD configuration necessaryfor osg-xrootd-standalone
-META_XROOTD_CFG_TEXT = """\
+# XRootD configuration necessary for osg-xrootd-standalone
+STANDALONE_XROOTD_CFG_TEXT = """\
 set rootdir = /
 set resourcename = OSG_TEST_XROOTD_STANDALONE
 xrd.tls /etc/grid-security/xrd/xrdcert.pem /etc/grid-security/xrd/xrdkey.pem
 xrd.tlsca noverify
+acc.authdb /etc/xrootd/auth_file
+ofs.authorize
 """
 
 AUTHFILE_TEXT = """\
@@ -35,42 +23,29 @@ u = /tmp/@=/ a
 u xrootd /tmp a
 """
 
-SYSCONFIG_TEXT = """\
-XROOTD_USER=xrootd
-XROOTD_GROUP=xrootd
 
-XROOTD_DEFAULT_OPTIONS="-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
-CMSD_DEFAULT_OPTIONS="-l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
-PURD_DEFAULT_OPTIONS="-l /var/log/xrootd/purged.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
-XFRD_DEFAULT_OPTIONS="-l /var/log/xrootd/xfrd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"
 
-XROOTD_INSTANCES="default"
-CMSD_INSTANCES="default"
-PURD_INSTANCES="default"
-XFRD_INSTANCES="default"
-"""
 
 
 class TestStartXrootd(osgunittest.OSGTestCase):
 
     def setUp(self):
+        core.skip_ok_unless_installed("xrootd", "osg-xrootd-standalone", by_dependency=True)
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
                             "xcache 1.0.2+ configs conflict with xrootd tests")
 
     def test_01_configure_xrootd(self):
-        core.config['xrootd.pid-file'] = '/var/run/xrootd/xrootd-default.pid'
         core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'
         core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'
-        if core.rpm_is_installed('osg-xrootd-standalone'):
-            # rootdir and resourcename needs to be set early for the default osg-xrootd config
-            core.config['xrootd.config'] = '/etc/xrootd/config.d/10-osg-test.cfg'
-        else:
-            core.config['xrootd.config'] = '/etc/xrootd/config.d/99-osg-test.cfg'
+        # rootdir and resourcename needs to be set early for the default osg-xrootd config
+        core.config['xrootd.config'] = '/etc/xrootd/config.d/10-osg-test.cfg'
         core.config['xrootd.service-defaults'] = '/etc/sysconfig/xrootd'
         core.config['xrootd.multiuser'] = False
         core.state['xrootd.started-server'] = False
         core.state['xrootd.backups-exist'] = False
+
+        xrootd_config = STANDALONE_XROOTD_CFG_TEXT
 
         self.skip_ok_unless(core.options.adduser, 'user not created')
         core.skip_ok_unless_installed('xrootd', 'globus-proxy-utils', by_dependency=True)
@@ -79,27 +54,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.install_cert('certs.xrootdcert', 'certs.hostcert', 'xrootd', 0o644)
         core.install_cert('certs.xrootdkey', 'certs.hostkey', 'xrootd', 0o400)
 
-        if core.rpm_is_installed('osg-xrootd-standalone'):
-            core.log_message("Using osg-xrootd configuration")
-            xrootd_config = META_XROOTD_CFG_TEXT
-        else:
-            lcmaps_packages = ('lcmaps', 'lcmaps-db-templates', 'xrootd-lcmaps', 'vo-client', 'vo-client-lcmaps-voms')
-            if all([core.rpm_is_installed(x) for x in lcmaps_packages]):
-                core.log_message("Using xrootd-lcmaps authentication")
-                sec_protocol = '-authzfun:libXrdLcmaps.so -authzfunparms:loglevel=5,policy=authorize_only'
-            else:
-                core.log_message("Using XRootD mapfile authentication")
-                sec_protocol = '-gridmap:/etc/grid-security/xrd/xrdmapfile'
-                files.write("/etc/grid-security/xrd/xrdmapfile", "\"%s\" vdttest" % core.config['user.cert_subject'],
-                            owner="xrootd",
-                            chown=(user.pw_uid, user.pw_gid))
-            xrootd_config = XROOTD_CFG_TEXT % sec_protocol
-
         files.write(core.config['xrootd.config'], xrootd_config, owner='xrootd', backup=True, chmod=0o644)
-
-        if core.el_release() < 7:
-            files.write(core.config['xrootd.service-defaults'], SYSCONFIG_TEXT,
-                        owner="xrootd", chown=(user.pw_uid, user.pw_gid), chmod=0o644)
 
         authfile = '/etc/xrootd/auth_file'
         files.write(authfile, AUTHFILE_TEXT, owner="xrootd", chown=(user.pw_uid, user.pw_gid))

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -28,9 +28,17 @@ acc.authdb /etc/xrootd/auth_file
 ofs.authorize
 """
 
+# Authfile syntax is described in https://xrootd.slac.stanford.edu/doc/dev50/sec_config.htm#_Toc64492263
+# Privileges used are "a" (all) and "rl" (read only).
+# All paths are relative to the rootdir defined above
 AUTHFILE_TEXT = """\
+# A user has full privileges to a directory named after them (e.g. matyas has /matyas/, vdttest has /vdttest/)
 u =      /@=/ a
+
+# The xrootd user has full privileges to the top-level directory
 u xrootd / a
+
+# All users (including unauth users) have full privileges to /public/, and read-only ("rl") privileges to the top-level directory
 u *      /public/ a / rl
 """
 
@@ -118,6 +126,8 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.state['xrootd.backups-exist'] = True
         core.state['xrootd.is-configured'] = True
 
+    # Make sure the directories are set up correctly and that the xrootd user
+    # can access everything it's supposed to be able to.
     def test_02_xrootd_user_file_access(self):
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
         public_subdir = core.config['xrootd.public_subdir']
@@ -145,6 +155,8 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         finally:
             os.setegid(os.getgid())
 
+    # Make sure the directories are set up correctly and that the test user
+    # can access everything it's supposed to be able to.
     def test_03_test_user_file_access(self):
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
         username = core.options.username

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -70,7 +70,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
 
     def test_01_configure_xrootd(self):
         core.state['xrootd.is-configured'] = False
-        core.config['xrootd.security'] = None
+        core.config['xrootd.security'] = []
         core.config['certs.xrootdcert'] = '/etc/grid-security/xrd/xrdcert.pem'
         core.config['certs.xrootdkey'] = '/etc/grid-security/xrd/xrdkey.pem'
         # rootdir and resourcename needs to be set early for the default osg-xrootd config
@@ -91,12 +91,12 @@ class TestStartXrootd(osgunittest.OSGTestCase):
 
         if core.osg_release().version < '3.6':
             core.skip_ok_unless_installed("globus-proxy-utils")
-            core.config['xrootd.security'] = "GSI"
+            core.config['xrootd.security'].append("GSI")
 
         else:  # 3.6+
         # FIXME: remove else after https://opensciencegrid.atlassian.net/browse/SOFTWARE-4858 is released
             core.skip_ok_unless_installed("xrootd-scitokens")
-            core.config['xrootd.security'] = "SCITOKENS"
+            core.config['xrootd.security'].append("SCITOKENS")
 
         core.install_cert('certs.xrootdcert', 'certs.hostcert', 'xrootd', 0o644)
         core.install_cert('certs.xrootdkey', 'certs.hostkey', 'xrootd', 0o400)
@@ -207,8 +207,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.config['xrootd.multiuser'] = True
 
     def test_06_configure_scitokens(self):
-        # FIXME: drop this test after https://opensciencegrid.atlassian.net/browse/SOFTWARE-4858 is released
-        self.skip_ok_unless(core.config['xrootd.security'] == "SCITOKENS", "Not using SciTokens for XRootD")
+        self.skip_ok_unless("SCITOKENS" in core.config['xrootd.security'], "Not using SciTokens for XRootD")
         scitokens_conf_path = "/etc/xrootd/scitokens.conf"
         files.write(scitokens_conf_path, SCITOKENS_CONF_TEXT, owner='xrootd', chmod=0o644)
 
@@ -240,7 +239,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         self.assertRegexInList(xrootd_config,
                                r"^[ ]*ofs\.authorize[ ]*$",
                                "ofs.authorize missing")
-        if core.config['xrootd.security'] == "SCITOKENS":
+        if "SCITOKENS" in core.config['xrootd.security']:
             self.assertRegexInList(xrootd_config,
                                    r"^[ ]*ofs\.authlib[ ]+[+][+][ ]+libXrdAccSciTokens\.so[ ]+config=/etc/xrootd/scitokens\.conf[ ]*$",
                                    "scitokens config not getting loaded")

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -234,7 +234,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
                                rf"^[ ]*oss\.localroot[ ]+{xrootd.ROOTDIR}[ ]*$",
                                "oss.localroot not being set correctly")
         self.assertRegexInList(xrootd_config,
-                               r"^[ ]*acc\.authdb[ ]+/etc/xrootd/auth_file[ ]*$",
+                               r"^[ ]*acc\.authdb[ ]+/etc/xrootd/Authfile[ ]*$",
                                "authfile not being set correctly")
         self.assertRegexInList(xrootd_config,
                                r"^[ ]*ofs\.authorize[ ]*$",

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -193,6 +193,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
         core.config['xrootd.multiuser'] = True
 
     def test_06_configure_scitokens(self):
+        # FIXME: drop this test after https://opensciencegrid.atlassian.net/browse/SOFTWARE-4858 is released
         self.skip_ok_unless(core.config['xrootd.security'] == "SCITOKENS", "Not using SciTokens for XRootD")
         scitokens_conf_path = "/etc/xrootd/scitokens.conf"
         files.write(scitokens_conf_path, SCITOKENS_CONF_TEXT, owner='xrootd', chmod=0o644)

--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -128,6 +128,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
 
     # Make sure the directories are set up correctly and that the xrootd user
     # can access everything it's supposed to be able to.
+    # TODO: Remove before merging into master
     def test_02_xrootd_user_file_access(self):
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
         public_subdir = core.config['xrootd.public_subdir']
@@ -157,6 +158,7 @@ class TestStartXrootd(osgunittest.OSGTestCase):
 
     # Make sure the directories are set up correctly and that the test user
     # can access everything it's supposed to be able to.
+    # TODO: Remove before merging into master
     def test_03_test_user_file_access(self):
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
         username = core.options.username

--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -10,11 +10,11 @@ import osgtest.library.xrootd as xrootd
 HTTP_PORT1 = 9001  # chosen so it doesn't conflict w/ the stashcache instances
 HTTP_PORT2 = 9002
 
-XROOTD_CFG_TEXT = """\
+XROOTD_CFG_TEXT = f"""\
 all.adminpath /var/spool/xrootd
 all.pidpath /var/run/xrootd
 set resourcename = VDTTEST
-set rootdir = /
+set rootdir = {xrootd.ROOTDIR}
 continue /etc/xrootd/config.d/
 """
 

--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -60,6 +60,7 @@ class TestStartXrootdTPC(osgunittest.OSGTestCase):
                                       by_dependency=True)
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
+        self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
 
     def test_01_configure_xrootd(self):
         core.config['xrootd.tpc.config-1'] = '/etc/xrootd/xrootd-third-party-copy-1.cfg'

--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -97,15 +97,15 @@ class TestStartXrootdTPC(osgunittest.OSGTestCase):
                     chmod=0o644)
         files.write(core.config['xrootd.tpc.basic-config'],
                     XROOTD_TPC_TXT +
-                    (XROOTD_MACAROON_TXT if core.config['xrootd.security'] == "GSI" else ""),
+                    (XROOTD_MACAROON_TXT if "GSI" in core.config['xrootd.security'] else ""),
                     owner='xrootd', backup=True, chown=(user.pw_uid, user.pw_gid),
                     chmod=0o644)
 
         core.state['xrootd.tpc.backups-exist'] = True
  
     def test_02_create_macaroons(self):
-        self.skip_ok_if(core.config['xrootd.security'] != "GSI",
-                        "Macaroons use GSI")
+        self.skip_ok_unless("GSI" in core.config['xrootd.security'],
+                            "Our macaroons tests use GSI")
         core.config['xrootd.tpc.macaroon-secret-1'] = '/etc/xrootd/macaroon-secret-1'
         core.config['xrootd.tpc.macaroon-secret-2'] = '/etc/xrootd/macaroon-secret-2'
         core.check_system(["openssl", "rand", "-base64", "-out",

--- a/osgtest/tests/test_401_scitokens.py
+++ b/osgtest/tests/test_401_scitokens.py
@@ -21,7 +21,7 @@ class TestTokens(osgunittest.OSGTestCase):
         )
 
     def test_02_request_xrootd_scitokens(self):
-        self.skip_ok_unless(core.config.get('xrootd.security') == "SCITOKENS",
+        self.skip_ok_unless("SCITOKENS" in core.config.get('xrootd.security', []),
                             "Not using SciTokens for XRootD")
         try:
             credentials.request_scitoken(

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -18,6 +18,8 @@ class TestXrootd(osgunittest.OSGTestCase):
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
                             "xcache 1.0.2+ configs conflict with xrootd tests")
+        core.skip_ok_unless_installed("xrootd", "xrootd-client", by_dependency=True)
+        self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
 
     def test_01_xrdcp_local_to_server(self):
         core.state['xrootd.copied-to-server'] = False

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -29,6 +29,18 @@ class TestXrootd(osgunittest.OSGTestCase):
         core.skip_ok_unless_installed("xrootd", "xrootd-client", by_dependency=True)
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
 
+    def xrootd_url(self, path, auth=True):
+        if path.startswith(xrootd.ROOTDIR):
+            path = path[len(xrootd.ROOTDIR):]
+        url = f"root://{socket.getfqdn()}/{path}"
+        if (
+                auth and
+                core.config['xrootd.security'] == "SCITOKENS" and
+                not core.config['xrootd.ztn']
+        ):
+            url += f"?authz=Bearer%20{core.state['token.xrootd_contents']}"
+        return url
+
     def test_00_setup(self):
         public_subdir = core.config['xrootd.public_subdir']
         user_subdir = core.config['xrootd.user_subdir']

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -81,25 +81,40 @@ class TestXrootd(osgunittest.OSGTestCase):
         self.assertEqual(status, 0, fail)
         self.assert_(file_copied, 'Copied file missing')
 
-    def test_04_xrootd_fuse(self):
-        # This tests xrootd-fuse using a mount in /mnt
-        core.skip_ok_unless_installed('xrootd', 'xrootd-client', 'xrootd-fuse')
-        self.skip_ok_unless(os.path.exists("/mnt"), "/mnt did not exist")
-
-        if not os.path.exists(TestXrootd.__fuse_path):
-            os.mkdir(TestXrootd.__fuse_path)
-        hostname = socket.getfqdn()
-
-        # For some reason, sub process hangs on fuse processes, use os.system
-        os.system("mount -t fuse -o rdr=root://localhost//tmp,uid=xrootd xrootdfs %s" %
-                  TestXrootd.__fuse_path)
-
-        # Copy a file in and see if it made it into the fuse mount
-        xrootd_url = 'root://%s/%s/copied_file.txt' % (hostname, "/tmp")
-        core.system(['xrdcp', '--debug', '3', TestXrootd.__data_path, xrootd_url], user=True)
-
-        self.assert_(os.path.isfile("/tmp/copied_file.txt"), "Test file not uploaded to FUSE mount")
-
-        core.system(['umount', TestXrootd.__fuse_path])
-        os.rmdir(TestXrootd.__fuse_path)
-        files.remove("/tmp/copied_file.txt")
+    # Test dir reorg broke the FUSE test.  We can drop it for now due to low demand -mat 2021-10-14
+    # def test_07_xrootd_fuse(self):
+    #     # This tests xrootd-fuse using a mount in /mnt
+    #     core.skip_ok_unless_installed('xrootd-fuse')
+    #     self.skip_ok_unless(os.path.exists("/mnt"), "/mnt did not exist")
+    #
+    #     if not os.path.exists(TestXrootd.__fuse_path):
+    #         os.mkdir(TestXrootd.__fuse_path)
+    #
+    #     public_dir = xrootd.ROOTDIR + core.config['xrootd.public_subdir']
+    #
+    #     try:
+    #         self.skip_bad_unless_running(core.config['xrootd_service'])
+    #         # TODO: How to pass a scitoken to the mount?
+    #         # For some reason, sub process hangs on fuse processes, use os.system
+    #         cmd = f"mount -t fuse -o rdr=root://localhost/{public_dir},uid=xrootd xrootdfs {TestXrootd.__fuse_path}"
+    #         core.log_message(cmd)
+    #         ret = os.system(cmd)
+    #         self.assertEqual(ret, 0, f"FUSE mount failed with code {ret}")
+    #         try:
+    #             core.system(["ls", "-l", os.path.dirname(TestXrootd.__fuse_path)])
+    #             self.assertTrue(os.path.exists(TestXrootd.__fuse_path), "FUSE mounted filesystem is broken")
+    #             # Copy a file in and see if it made it into the fuse mount
+    #             xrootd_url = self.xrootd_url(TestXrootd.public_copied_file2)
+    #             core.system(['xrdcp', '--debug', '3', TestXrootd.__data_path, xrootd_url], user=True)
+    #             core.system(['find', TestXrootd.__fuse_path, '-ls'])
+    #             rel_copied_file2 = os.path.relpath(TestXrootd.public_copied_file2, public_dir)
+    #             fuse_copied_file2 = os.path.join(TestXrootd.__fuse_path, rel_copied_file2)
+    #             self.assert_(os.path.isfile(fuse_copied_file2), f"Test file not uploaded to FUSE mount at {fuse_copied_file2}")
+    #             files.remove(TestXrootd.public_copied_file2)
+    #         finally:
+    #             core.system(['umount', TestXrootd.__fuse_path])
+    #     except AssertionError:
+    #         core.state['xrootd.had-failures'] = True
+    #         raise
+    #     finally:
+    #         os.rmdir(TestXrootd.__fuse_path)

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -7,6 +7,8 @@ import pwd
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+import osgtest.library.xrootd as xrootd
 
 
 class TestXrootd(osgunittest.OSGTestCase):
@@ -14,12 +16,30 @@ class TestXrootd(osgunittest.OSGTestCase):
     __data_path = '/usr/share/osg-test/test_gridftp_data.txt'
     __fuse_path = '/mnt/xrootd_fuse_test'
 
+    public_copied_file = f"{xrootd.ROOTDIR}/{{public_subdir}}/public_copied_file.txt"
+    public_copied_file2 = f"{xrootd.ROOTDIR}/{{public_subdir}}/public_copied_file2.txt"
+    user_copied_file = f"{xrootd.ROOTDIR}/{{user_subdir}}/user_copied_file.txt"
+    file_to_download = f"{xrootd.ROOTDIR}/{{public_subdir}}/file_to_download.txt"
+    rootdir_copied_file = f"{xrootd.ROOTDIR}/rootdir_copied_file.txt"
+
     def setUp(self):
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
                             "xcache 1.0.2+ configs conflict with xrootd tests")
         core.skip_ok_unless_installed("xrootd", "xrootd-client", by_dependency=True)
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
+
+    def test_00_setup(self):
+        public_subdir = core.config['xrootd.public_subdir']
+        user_subdir = core.config['xrootd.user_subdir']
+        for var in [
+            "public_copied_file",
+            "public_copied_file2",
+            "user_copied_file",
+            "file_to_download",
+            "rootdir_copied_file",
+        ]:
+            setattr(TestXrootd, var, getattr(TestXrootd, var).format(**locals()))
 
     def test_01_xrdcp_local_to_server(self):
         core.state['xrootd.copied-to-server'] = False

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -112,6 +112,23 @@ class TestXrootd(osgunittest.OSGTestCase):
             core.state['xrootd.had-failures'] = True
             raise
 
+    def test_04a_xrdcp_upload_gsi_authenticated_denied(self):
+        self.skip_ok_unless("GSI" in core.config['xrootd.security'], "not using GSI")
+        try:
+            self.skip_bad_unless_running(core.config['xrootd_service'])
+            xrootd_url = self.xrootd_url(TestXrootd.rootdir_copied_file, add_token=False)
+            command = ('xrdcp', '--debug', '3', TestXrootd.__data_path, xrootd_url)
+            core.check_system(command, "Authenticated xrdcp upload to dir w/o write access (should be denied)", exit=54, user=True)
+            self.assertFalse(os.path.exists(TestXrootd.rootdir_copied_file), "Uploaded file wrongly present")
+        except AssertionError:
+            core.state['xrootd.had-failures'] = True
+            raise
+        finally:
+            try:
+                files.remove(TestXrootd.rootdir_copied_file)
+            except FileNotFoundError:
+                pass
+
     def test_04b_xrdcp_upload_scitoken_authenticated_denied(self):
         self.skip_ok_unless("SCITOKENS" in core.config['xrootd.security'], "not using scitokens")
         token_contents = core.state['token.xrootd_contents']

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -14,6 +14,7 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
                                       by_dependency=True)
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
+        self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")
 
     def test_01_create_macaroons(self):
         core.config['xrootd.tpc.macaroon-1'] = None

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -62,8 +62,8 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
                           "failed to prepare source file")
 
     def test_01_create_macaroons(self):
-        self.skip_ok_unless(core.config['xrootd.security'] == "GSI",
-                            "macaroons uses GSI")
+        self.skip_ok_unless("GSI" in core.config['xrootd.security'],
+                            "Our macaroons tests use GSI")
         core.config['xrootd.tpc.macaroon-1'] = None
         core.config['xrootd.tpc.macaroon-2'] = None
         core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
@@ -123,13 +123,14 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
 
     def test_04_initiate_tpc_authenticated(self):
         token1 = token2 = ""
-        if core.config['xrootd.security'] == "GSI":
+        # TODO Make these not be mutually exclusive
+        if "GSI" in core.config['xrootd.security']:
             core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)
             token1 = core.config['xrootd.tpc.macaroon-1']
             token2 = core.config['xrootd.tpc.macaroon-2']
             self.skip_bad_unless(token1 and token2, "TPC macaroons not created")
             security_type = "macaroons"
-        elif core.config['xrootd.security'] == "SCITOKENS":
+        elif "SCITOKENS" in core.config['xrootd.security']:
             core.skip_ok_unless_installed('xrootd-scitokens', by_dependency=True)
             token1 = core.state['token.xrootd_tpc_1_contents']
             token2 = core.state['token.xrootd_tpc_2_contents']

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -62,6 +62,8 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
                           "failed to prepare source file")
 
     def test_01_create_macaroons(self):
+        self.skip_ok_unless(core.config['xrootd.security'] == "GSI",
+                            "macaroons uses GSI")
         core.config['xrootd.tpc.macaroon-1'] = None
         core.config['xrootd.tpc.macaroon-2'] = None
         core.skip_ok_unless_installed('x509-scitokens-issuer-client', by_dependency=True)

--- a/osgtest/tests/test_465_xrootd_tpc.py
+++ b/osgtest/tests/test_465_xrootd_tpc.py
@@ -15,6 +15,29 @@ class TestXrootdTPC(osgunittest.OSGTestCase):
     public_copied_file = f"{xrootd.ROOTDIR}/{{public_subdir}}/tpc_public_copied_file.txt"
     public_copied_file2 = f"{xrootd.ROOTDIR}/{{public_subdir}}/tpc_public_copied_file2.txt"
     user_copied_file = f"{xrootd.ROOTDIR}/{{user_subdir}}/tpc_user_copied_file.txt"
+
+    def tpc1_url_from_path(self, path):
+        if path.startswith(xrootd.ROOTDIR):
+            path = path[len(xrootd.ROOTDIR):]
+        return f"https://{core.get_hostname()}:9001/{path}"
+
+    def tpc2_url_from_path(self, path):
+        if path.startswith(xrootd.ROOTDIR):
+            path = path[len(xrootd.ROOTDIR):]
+        return f"https://{core.get_hostname()}:9002/{path}"
+
+    def copy_command(self, source_url, dest_url, source_token=None, dest_token=None):
+        command = ["curl", "-A", "Test", "-vk", "-X", "COPY",
+                   "-H", f"Source: {source_url}",
+                   "-H", "Overwrite: T",
+        ]
+        if dest_token:
+            command.extend(["-H", f"Authorization: Bearer {dest_token}"])
+        if source_token:
+            command.extend(["-H", f"Copy-Header:  Authorization: Bearer {source_token}"])
+        command.append(dest_url)
+        return command
+
     @core.elrelease(7,8)
     def setUp(self):
         core.skip_ok_unless_installed("osg-xrootd-standalone",

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -34,3 +34,7 @@ class TestStopXrootdTPC(osgunittest.OSGTestCase):
         service.check_stop(core.config['xrootd_tpc_service_1'])
         service.check_stop(core.config['xrootd_tpc_service_2'])
 
+    def test_03_remove_macaroons(self):
+        self.skip_ok_unless(core.config['xrootd.security'] == "GSI", "macaroons uses GSI")
+        files.remove(core.config['xrootd.tpc.macaroon-secret-1'], force=True)
+        files.remove(core.config['xrootd.tpc.macaroon-secret-2'], force=True)

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -10,6 +10,7 @@ class TestStopXrootdTPC(osgunittest.OSGTestCase):
                                       by_dependency=True)
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
+        self.skip_ok_unless(core.config['xrootd.security'], "no xrootd security available")
 
     def test_01_stop_xrootd(self):
         if core.state['xrootd.tpc.backups-exist']:

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -2,6 +2,7 @@ import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.service as service
 import osgtest.library.osgunittest as osgunittest
+import osgtest.library.xrootd as xrootd
 
 class TestStopXrootdTPC(osgunittest.OSGTestCase):
     @core.elrelease(7,8)
@@ -12,12 +13,20 @@ class TestStopXrootdTPC(osgunittest.OSGTestCase):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2", "xcache 1.0.2+ configs conflict with xrootd tests")
         self.skip_ok_unless(core.config['xrootd.security'], "no xrootd security available")
 
-    def test_01_stop_xrootd(self):
+    def test_01_dump_logs_if_failures(self):
+        self.skip_ok_unless(core.state['xrootd.tpc.had-failures'], "no failures")
+        self.skip_ok_unless(core.options.manualrun, "only dumping logs on a manual run (osg-test -m)")
+        xrootd.dump_log(500, "third-party-copy-1")
+        xrootd.dump_log(500, "third-party-copy-2")
+
+    def test_02_stop_xrootd_tpc(self):
         if core.state['xrootd.tpc.backups-exist']:
             files.restore(core.config['xrootd.tpc.config-1'], "xrootd")
             files.restore(core.config['xrootd.tpc.config-2'], "xrootd")
             files.restore(core.config['xrootd.tpc.basic-config'], "xrootd")
             files.restore('/etc/xrootd/config.d/40-osg-standalone.cfg', "xrootd")
+            files.restore(xrootd.logfile("third-party-copy-1"), "xrootd", ignore_missing=True)
+            files.restore(xrootd.logfile("third-party-copy-2"), "xrootd", ignore_missing=True)
 
         self.skip_ok_if(not core.state['xrootd.started-http-server-1'] and
                         not core.state['xrootd.started-http-server-2'], 
@@ -25,5 +34,3 @@ class TestStopXrootdTPC(osgunittest.OSGTestCase):
         service.check_stop(core.config['xrootd_tpc_service_1'])
         service.check_stop(core.config['xrootd_tpc_service_2'])
 
-    def test_02_clean_test_files(self):
-        files.remove("/tmp/test_gridftp_data_tpc.txt", force=True)

--- a/osgtest/tests/test_838_xrootd_tpc.py
+++ b/osgtest/tests/test_838_xrootd_tpc.py
@@ -35,6 +35,6 @@ class TestStopXrootdTPC(osgunittest.OSGTestCase):
         service.check_stop(core.config['xrootd_tpc_service_2'])
 
     def test_03_remove_macaroons(self):
-        self.skip_ok_unless(core.config['xrootd.security'] == "GSI", "macaroons uses GSI")
+        self.skip_ok_unless("GSI" in core.config['xrootd.security'], "Our macaroons tests use GSI")
         files.remove(core.config['xrootd.tpc.macaroon-secret-1'], force=True)
         files.remove(core.config['xrootd.tpc.macaroon-secret-2'], force=True)

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -17,8 +17,11 @@ class TestStopXrootd(osgunittest.OSGTestCase):
             files.restore(core.config['xrootd.config'], "xrootd")
             files.restore(core.config['xrootd.logging-config'], "xrootd")
             files.restore('/etc/xrootd/auth_file', "xrootd")
-            if not core.rpm_is_installed('xrootd-lcmaps'):
+            if not core.rpm_is_installed('xrootd-lcmaps') and core.config['xrootd.security'] == "GSI":
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")
+            if core.config['xrootd.security'] == "SCITOKENS":
+                files.restore('/etc/xrootd/scitokens.conf', "xrootd")
+                files.remove("/etc/xrootd/config.d/99-osgtest-ztn.cfg", force=True)
         core.skip_ok_unless_installed('xrootd', 'globus-proxy-utils', by_dependency=True)
         self.skip_ok_if(core.state['xrootd.started-server'], 'did not start server')
         service.check_stop(core.config['xrootd_service'])

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -15,6 +15,7 @@ class TestStopXrootd(osgunittest.OSGTestCase):
     def test_01_stop_xrootd(self):
         if core.state['xrootd.backups-exist']:
             files.restore(core.config['xrootd.config'], "xrootd")
+            files.restore(core.config['xrootd.logging-config'], "xrootd")
             files.restore('/etc/xrootd/auth_file', "xrootd")
             if not core.rpm_is_installed('xrootd-lcmaps'):
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -9,6 +9,8 @@ class TestStopXrootd(osgunittest.OSGTestCase):
         if core.rpm_is_installed("xcache"):
             self.skip_ok_if(core.PackageVersion("xcache") >= "1.0.2",
                             "xcache 1.0.2+ configs conflict with xrootd tests")
+        core.skip_ok_unless_installed("xrootd", "osg-xrootd-standalone", by_dependency=True)
+
 
     def test_01_stop_xrootd(self):
         if core.state['xrootd.backups-exist']:
@@ -16,8 +18,6 @@ class TestStopXrootd(osgunittest.OSGTestCase):
             files.restore('/etc/xrootd/auth_file', "xrootd")
             if not core.rpm_is_installed('xrootd-lcmaps'):
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")
-            if core.el_release() < 7:
-                files.restore(core.config['xrootd.service-defaults'], "xrootd")
         core.skip_ok_unless_installed('xrootd', 'globus-proxy-utils', by_dependency=True)
         self.skip_ok_if(core.state['xrootd.started-server'], 'did not start server')
         service.check_stop(core.config['xrootd_service'])

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -26,9 +26,9 @@ class TestStopXrootd(osgunittest.OSGTestCase):
             files.restore(core.config['xrootd.logging-config'], "xrootd")
             files.restore('/etc/xrootd/auth_file', "xrootd")
             files.restore(xrootd.logfile("standalone"), "xrootd", ignore_missing=True)
-            if not core.rpm_is_installed('xrootd-lcmaps') and core.config['xrootd.security'] == "GSI":
+            if not core.rpm_is_installed('xrootd-lcmaps') and "GSI" in core.config['xrootd.security']:
                 files.restore('/etc/grid-security/xrd/xrdmapfile', "xrootd")
-            if core.config['xrootd.security'] == "SCITOKENS":
+            if "SCITOKENS" in core.config['xrootd.security']:
                 files.restore('/etc/xrootd/scitokens.conf', "xrootd")
                 files.remove("/etc/xrootd/config.d/99-osgtest-ztn.cfg", force=True)
             if os.path.exists(xrootd.ROOTDIR):

--- a/osgtest/tests/test_840_xrootd.py
+++ b/osgtest/tests/test_840_xrootd.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+
 import osgtest.library.core as core
 import osgtest.library.files as files
 import osgtest.library.service as service
@@ -28,6 +31,8 @@ class TestStopXrootd(osgunittest.OSGTestCase):
             if core.config['xrootd.security'] == "SCITOKENS":
                 files.restore('/etc/xrootd/scitokens.conf', "xrootd")
                 files.remove("/etc/xrootd/config.d/99-osgtest-ztn.cfg", force=True)
+            if os.path.exists(xrootd.ROOTDIR):
+                shutil.rmtree(xrootd.ROOTDIR)
 
         # Get xrootd service back to its original state
         self.skip_ok_unless(core.state['xrootd.is-configured'], "xrootd is not configured")


### PR DESCRIPTION
Fairly large overhaul of the xrootd test code; this creates a directory structure with which it can test both authenticated and unauthenticated access.

SciTokens are used for tests on 3.6; GSI/Macaroons are used for tests on 3.5. I also added a test to run `cconfig` and make sure that the overall xrootd config, which is assembled from multiple config files, contains the right values for some of the knobs we care about.

Known issues:
- FUSE tests are broken (unknown failure)
- Macaroons tests are broken (the destination token does not have the right permissions)
- SciTokens tests are only run on 3.6, not 3.5+upcoming -- this is because 3.5's osg-xrootd-standalone sets up GSI
- xrdvoms/vomsxrd/xrootd-voms-plugin is not tested yet


The commits in this PR are not in chronological order; instead I grouped changes into chunks and made commits for those in order to try and make a consistent "story"; especially the "Reorganize test directory to check privileges" series of commits should be taken as a whole (don't expect a revert to work). The first few commits (up to "Add logging config...") are probably independent.

VMU test forthcoming.