### PR TITLE
Use voms-proxy-init to get grid proxies if needed

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -46,7 +46,7 @@ config['system.mapfile'] = '/etc/grid-security/grid-mapfile'
 # prefix each key with "COMP.", where "COMP" is a short lowercase string that
 # indicates which component the test belongs to, or "general." for truly cross-
 # cutting objects.
-state = {'proxy.valid': False}  # TODO: Drop 'proxy.valid' after we drop support for OSG 3.5
+state = {'proxy.valid': False}
 
 class DummyClass(object):
     """A class that ignores all function calls; useful for testing"""

--- a/osgtest/library/voms.py
+++ b/osgtest/library/voms.py
@@ -9,6 +9,8 @@ from osgtest.library import mysql
 from osgtest.library import osgunittest
 
 
+VONAME = "osgtestvo"
+
 
 def _get_sqlloc():
     # Find full path to libvomsmysql.so

--- a/osgtest/tests/test_200_voms.py
+++ b/osgtest/tests/test_200_voms.py
@@ -24,7 +24,7 @@ class TestStartVOMS(osgunittest.OSGTestCase):
         core.install_cert('certs.vomskey', 'certs.hostkey', 'voms', 0o400)
 
     def test_04_config_voms(self):
-        core.config['voms.vo'] = 'osgtestvo'
+        core.config['voms.vo'] = voms.VONAME
         core.config['voms.lock-file'] = '/var/lock/subsys/voms.osgtestvo'
         # The DB created by voms-admin would have the user 'admin-osgtestvo',
         # but the voms_install_db script provided by voms-server does not
@@ -33,6 +33,13 @@ class TestStartVOMS(osgunittest.OSGTestCase):
 
     def test_05_create_vo(self):
         voms.skip_ok_unless_installed()
+
+        # Destroy the DB if it already exists
+        try:
+            voms.destroy_db(core.config['voms.vo'], core.config['voms.dbusername'])
+            voms.destroy_voms_conf(core.config['voms.vo'])
+        except (EnvironmentError, AssertionError):
+            pass
 
         voms.create_vo(vo=core.config['voms.vo'],
                        dbusername=core.config['voms.dbusername'],


### PR DESCRIPTION
Some tests (even in OSG 3.6) need grid proxies which we can get with
voms-proxy-init if grid-proxy-init is not available.

Also do some cleanup and defensive coding for VOMS.
