### PR TITLE
Revert "Use voms-proxy-init to get grid proxies if needed"

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -46,7 +46,7 @@ config['system.mapfile'] = '/etc/grid-security/grid-mapfile'
 # prefix each key with "COMP.", where "COMP" is a short lowercase string that
 # indicates which component the test belongs to, or "general." for truly cross-
 # cutting objects.
-state = {'proxy.valid': False}
+state = {'proxy.valid': False}  # TODO: Drop 'proxy.valid' after we drop support for OSG 3.5
 
 class DummyClass(object):
     """A class that ignores all function calls; useful for testing"""

--- a/osgtest/library/voms.py
+++ b/osgtest/library/voms.py
@@ -9,8 +9,6 @@ from osgtest.library import mysql
 from osgtest.library import osgunittest
 
 
-VONAME = "osgtestvo"
-
 
 def _get_sqlloc():
     # Find full path to libvomsmysql.so

--- a/osgtest/tests/test_200_voms.py
+++ b/osgtest/tests/test_200_voms.py
@@ -24,7 +24,7 @@ class TestStartVOMS(osgunittest.OSGTestCase):
         core.install_cert('certs.vomskey', 'certs.hostkey', 'voms', 0o400)
 
     def test_04_config_voms(self):
-        core.config['voms.vo'] = voms.VONAME
+        core.config['voms.vo'] = 'osgtestvo'
         core.config['voms.lock-file'] = '/var/lock/subsys/voms.osgtestvo'
         # The DB created by voms-admin would have the user 'admin-osgtestvo',
         # but the voms_install_db script provided by voms-server does not
@@ -33,13 +33,6 @@ class TestStartVOMS(osgunittest.OSGTestCase):
 
     def test_05_create_vo(self):
         voms.skip_ok_unless_installed()
-
-        # Destroy the DB if it already exists
-        try:
-            voms.destroy_db(core.config['voms.vo'], core.config['voms.dbusername'])
-            voms.destroy_voms_conf(core.config['voms.vo'])
-        except (EnvironmentError, AssertionError):
-            pass
 
         voms.create_vo(vo=core.config['voms.vo'],
                        dbusername=core.config['voms.dbusername'],

--- a/osgtest/tests/test_407_voms.py
+++ b/osgtest/tests/test_407_voms.py
@@ -17,10 +17,6 @@ class TestVOMS(osgunittest.OSGTestCase):
         stdout = core.check_system(command, 'Run voms-proxy-info', user=True)[0]
         self.assert_(('/%s/Role=NULL' % (core.config['voms.vo'])) in stdout, msg)
 
-    def test_00_setup(self):
-        core.state.setdefault('voms.got-proxy', False)
-        core.state.setdefault('proxy.valid', False)
-
     def test_01_add_user(self):
         core.state['voms.added-user'] = False
         voms.skip_ok_unless_installed()
@@ -33,6 +29,8 @@ class TestVOMS(osgunittest.OSGTestCase):
         core.state['voms.added-user'] = True
 
     def test_02_good_voms_proxy_init(self):
+        core.state['voms.got-proxy'] = False
+
         voms.skip_ok_unless_installed()
         self.skip_bad_unless(core.state['voms.added-user'])
 
@@ -59,6 +57,8 @@ class TestVOMS(osgunittest.OSGTestCase):
         self.proxy_info('second voms-proxy-info output is ok')
 
     def test_06_rfc_voms_proxy_init(self):
+        core.state['voms.got-proxy'] = False
+
         voms.skip_ok_unless_installed()
         self.skip_bad_unless(core.state['voms.added-user'])
 
@@ -96,19 +96,3 @@ class TestVOMS(osgunittest.OSGTestCase):
             self.fail("Can't find proxy's signing algorithm")
         proxy_algorithm = match.group(1)
         self.assertEqual(cert_algorithm, proxy_algorithm)
-
-        core.state['proxy.valid'] = True
-
-    def test_09_basic_grid_proxy(self):
-        """
-        Use voms-proxy-init to create a basic grid proxy (without VOMS attributes)
-        if we don't already have one.  We may need this for tests in other modules.
-        """
-        core.skip_ok_unless_installed("voms-clients", by_dependency=True)
-        self.skip_ok_if(core.state['proxy.valid'], "Already have a proxy")
-        self.skip_bad_unless(core.state['voms.added-user'])
-
-        password = core.options.password + '\n'
-        core.check_system(['voms-proxy-init', '-rfc'], 'Run voms-proxy-init w/o VO', user=True, stdin=password)
-        core.check_system(['voms-proxy-info'], "Check resulting proxy", user=True)
-        core.state['proxy.valid'] = True


### PR DESCRIPTION
Reverts opensciencegrid/osg-test#243

> test_09_basic_grid_proxy (osgtest.tests.test_407_voms.TestVOMS) None
