### PR TITLE
Use voms-proxy-init to get certs attempt 2

### DIFF
--- a/osgtest/tests/special_user.py
+++ b/osgtest/tests/special_user.py
@@ -102,6 +102,7 @@ class TestUser(osgunittest.OSGTestCase):
         # Set up certificate
         globus_dir = os.path.join(core.state['user.pwd'].pw_dir, '.globus')
         core.state['user.cert_path'] = os.path.join(globus_dir, 'usercert.pem')
+        core.state['user.key_path'] = os.path.join(globus_dir, 'userkey.pem')
         test_ca = CA.load(core.config['certs.test-ca'])
         if not os.path.exists(core.state['user.cert_path']):
             test_ca.usercert(core.options.username, core.options.password)

--- a/osgtest/tests/test_407_voms.py
+++ b/osgtest/tests/test_407_voms.py
@@ -106,7 +106,10 @@ class TestVOMS(osgunittest.OSGTestCase):
         """
         core.skip_ok_unless_installed("voms-clients", by_dependency=True)
         self.skip_ok_if(core.state['proxy.valid'], "Already have a proxy")
-        self.skip_bad_unless(core.state['voms.added-user'])
+        self.skip_ok_unless(core.state.get('user.verified', False), "No user")
+        self.skip_ok_unless(os.path.isfile(core.state['user.cert_path']) and
+                            os.path.isfile(core.state['user.key_path']),
+                            "No user cert/key")
 
         password = core.options.password + '\n'
         core.check_system(['voms-proxy-init', '-rfc'], 'Run voms-proxy-init w/o VO', user=True, stdin=password)


### PR DESCRIPTION
Same objective as #243 except not broken. This time it checks if a user cert/key is available and doesn't try to make the proxy if it isn't (okskip).

I also have tests this time: https://osg-sw-submit.chtc.wisc.edu/tests/20211102-1152/packages.html
I replaced 'globus-proxy-utils' with 'voms-clients-cpp' in all the parameters files for this test. TPC failed to start because the config file was only created if globus-proxy-utils is installed -- obviously that only happens with this param set and is fixed in my branch anyway.