### PR TITLE
Test HTCondor-CE job sub w/o X.509 for unsupported HTCondor versions

### DIFF
--- a/osgtest/tests/test_410_jobs.py
+++ b/osgtest/tests/test_410_jobs.py
@@ -79,4 +79,8 @@ class TestRunJobs(osgunittest.OSGTestCase):
         else:
             core.log_message('condor WRITE token not found; skipping SCITOKENS auth')
 
-        self.run_job_in_tmp_dir(command, 'condor_ce_run a Condor job')
+        if core.osg_release() == "3.6" and core.PackageVersion('condor') < '9.0.8':
+            with core.no_x509(core.options.username):
+                self.run_job_in_tmp_dir(command, 'condor_ce_run a Condor job')
+        else:
+            self.run_job_in_tmp_dir(command, 'condor_ce_run a Condor job')

--- a/osgtest/tests/test_410_jobs.py
+++ b/osgtest/tests/test_410_jobs.py
@@ -79,7 +79,9 @@ class TestRunJobs(osgunittest.OSGTestCase):
         else:
             core.log_message('condor WRITE token not found; skipping SCITOKENS auth')
 
-        if core.osg_release() == "3.6" and core.PackageVersion('condor') < '9.0.8':
+        if core.osg_release() == "3.6" and \
+           core.PackageVersion('condor') >= '9.0.0' and \
+           core.PackageVersion('condor') < '9.0.8':
             with core.no_x509(core.options.username):
                 self.run_job_in_tmp_dir(command, 'condor_ce_run a Condor job')
         else:

--- a/osgtest/tests/test_550_condorce.py
+++ b/osgtest/tests/test_550_condorce.py
@@ -60,7 +60,9 @@ class TestCondorCE(osgunittest.OSGTestCase):
         cwd = os.getcwd()
         os.chdir('/tmp')
         self.command += ['condor_ce_trace', '--debug'] + list(args) + [core.get_hostname()]
-        if core.osg_release() == "3.6" and core.PackageVersion('condor') < '9.0.8':
+        if core.osg_release() == "3.6" and \
+           core.PackageVersion('condor') >= '9.0.0' and \
+           core.PackageVersion('condor') < '9.0.8':
             with core.no_x509(core.options.username):
                 trace_rc, trace_out, trace_err = core.system(self.command, user=True)
         else:

--- a/osgtest/tests/test_550_condorce.py
+++ b/osgtest/tests/test_550_condorce.py
@@ -60,7 +60,11 @@ class TestCondorCE(osgunittest.OSGTestCase):
         cwd = os.getcwd()
         os.chdir('/tmp')
         self.command += ['condor_ce_trace', '--debug'] + list(args) + [core.get_hostname()]
-        trace_rc, trace_out, trace_err = core.system(self.command, user=True)
+        if core.osg_release() == "3.6" and core.PackageVersion('condor') < '9.0.8':
+            with core.no_x509(core.options.username):
+                trace_rc, trace_out, trace_err = core.system(self.command, user=True)
+        else:
+            trace_rc, trace_out, trace_err = core.system(self.command, user=True)
         os.chdir(cwd)
 
         if trace_rc:


### PR DESCRIPTION
(SOFTWARE-4901)

Until 9.0.8, HTCondor requires GSI for proxy delegation so job
submission failed using HTCondor-CE client tools with a proxy.

Marking as `do-not-merge` as I haven't tested these changes.