### PR TITLE
allow rpm verifying virtual dependencies (SOFTWARE-5060)

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -339,9 +339,17 @@ def dependency_is_installed(a_dependency):
     Distinct from rpm_is_installed in that this handles virtual dependencies,
     such as 'grid-certificates'.
     """
+    return bool(dependency_installed_rpms(a_dependency))
+
+
+def dependency_installed_rpms(a_dependency):
+    """Returns a list of installed rpms satisfying a virtual dependency.
+    """
     status, stdout, stderr = system(('rpm', '--query', '--whatprovides', a_dependency),
                                     log_output=False, quiet=True)
-    return (status == 0) and not stdout.startswith('no package provides')
+    return (stdout.splitlines()
+            if (status == 0) and not stdout.startswith('no package provides')
+            else [])
 
 
 def installed_rpms():


### PR DESCRIPTION
Per SOFTWARE-5060:

  - Make this test understand virtual dependencies.
  - For each dependency, run rpm -q --whatprovides $dependency
    which will tell you which of the installed RPMs satisfy that
    dependency.
  - If none of them do (nonzero exit code), fail;
  - if one of them does, verify that one;
  - if multiple of them do, verify the first one.


Note, we provide a new alternate version of `dependency_is_installed` in `core` called `dependency_installed_rpms`, which does the same thing but returns a list of installed rpms matching a dependency rather than just the bool result.