### PR TITLE
Use default cgroup location, /sys/fs/cgroup (SOFTWARE-5500)

### DIFF
--- a/osgtest/tests/test_290_slurm.py
+++ b/osgtest/tests/test_290_slurm.py
@@ -42,7 +42,6 @@ StateSaveLocation=/var/spool/slurmd
 """
 
 SLURM_CGROUPS_CONFIG = """CgroupAutomount=yes
-CgroupMountpoint=/cgroup
 ConstrainCores=no
 ConstrainRAMSpace=no
 """


### PR DESCRIPTION
The old config resulted in errors like the following in slurm.log:

```
[2023-03-27T04:49:43.934] error: cannot read
/cgroup/system.slice/slurmd.service/cgroup.controllers: No such file or
directory
```

Success here https://osg-sw-submit.chtc.wisc.edu/tests/20230328-1359/results.html