### PR TITLE
SOFTWARE-5618: add test for osg-ca-manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The test software is written in Python and consists of:
 -   The tests themselves (also Python modules) in `osgtest/tests`
 -   Extra files needed at runtime in `files`
 
-The whole system uses the standard Python `unittest` framework to run. Note that all tests have to be compatible with Python 2.6; when reading the docs for `unittest`, keep note of when a feature was introduced.
+The whole system uses the standard Python `unittest` framework to run. 
 
 ### Test Sequence
 

--- a/files/test_sequence
+++ b/files/test_sequence
@@ -1,5 +1,6 @@
 test_040_java
 test_050_mysqld
+test_055_osg_ca_manage
 test_060_fetch_crl
 test_070_munge
 test_090_jobs

--- a/osgtest/tests/test_055_osg_ca_manage.py
+++ b/osgtest/tests/test_055_osg_ca_manage.py
@@ -15,7 +15,7 @@ class TestOsgCaManage(osgunittest.OSGTestCase):
         fail = core.diagnose('Run osg-ca-manage setupCA', command, status, stdout, stderr)
 
         self.assertEquals(status, 0, fail)
-        pem_count = len(glob.glob(os.path.join('/etc/grid-security/certificates', '*.pem')))
+        pem_count = len(glob.glob('/etc/grid-security/certificates/*.pem'))
         self.assert_(pem_count > 0, "No certificates installed")
 
     def test_02_verify_ca(self):

--- a/osgtest/tests/test_055_osg_ca_manage.py
+++ b/osgtest/tests/test_055_osg_ca_manage.py
@@ -1,0 +1,29 @@
+import glob
+import os
+
+import osgtest.library.core as core
+import osgtest.library.osgunittest as osgunittest
+
+
+class TestOsgCaManage(osgunittest.OSGTestCase):
+
+    def test_01_setup_ca(self):
+        """Test that a CA can be installed via `osg-ca-manage setupCA`"""
+        core.skip_ok_unless_installed('osg-ca-scripts')
+        command = ('osg-ca-manage', 'setupCA', '--location', 'root', '--url', 'osg')
+        status, stdout, stderr = core.system(command)
+        fail = core.diagnose('Run osg-ca-manage setupCA', command, status, stdout, stderr)
+
+        self.assertEquals(status, 0, fail)
+        pem_count = len(glob.glob(os.path.join('/etc/grid-security/certificates', '*.pem')))
+        self.assert_(pem_count > 0, "No certificates installed")
+
+    def test_02_verify_ca(self):
+        """Verify CA installation via `osg-ca-manage verify`"""
+        core.skip_ok_unless_installed('osg-ca-scripts')
+        command = ('osg-ca-manage', 'verify')
+        status, stdout, stderr = core.system(command)
+        fail = core.diagnose('Run osg-ca-manage verify', command, status, stdout, stderr)
+        
+        # Nothing to confirm besides success of verify command
+        self.assertEquals(status, 0, fail)

--- a/osgtest/tests/test_060_fetch_crl.py
+++ b/osgtest/tests/test_060_fetch_crl.py
@@ -55,7 +55,7 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         else:
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join('/etc/grid-security/certificates', '*.r[0-9]')))
-        self.assert_(count > 3, True)
+        self.assert_(count > 3, "Expected > 3 crls but found %s" % count)
 
     def test_02_fetch_crl_dir(self):
         core.skip_ok_unless_installed('fetch-crl')
@@ -73,4 +73,4 @@ class TestFetchCrl(osgunittest.OSGTestCase):
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join(temp_crl_dir, '*.r[0-9]')))
         shutil.rmtree(temp_crl_dir)
-        self.assert_(count > 3, True)
+        self.assert_(count > 3, "Expected > 3 crls but found %s" % count)

--- a/osgtest/tests/test_060_fetch_crl.py
+++ b/osgtest/tests/test_060_fetch_crl.py
@@ -55,7 +55,7 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         else:
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join('/etc/grid-security/certificates', '*.r[0-9]')))
-        self.assert_(count > 3, "Expected > 3 crls but found %s" % count)
+        self.assert_(count > 3, f"Expected > 3 crls but found {count}")
 
     def test_02_fetch_crl_dir(self):
         core.skip_ok_unless_installed('fetch-crl')
@@ -73,4 +73,4 @@ class TestFetchCrl(osgunittest.OSGTestCase):
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join(temp_crl_dir, '*.r[0-9]')))
         shutil.rmtree(temp_crl_dir)
-        self.assert_(count > 3, "Expected > 3 crls but found %s" % count)
+        self.assert_(count > 3, f"Expected > 3 crls but found {count}")


### PR DESCRIPTION
- Add new integration test to be run before fetch_crl that installs CAs via `osg-ca-manage`
- Add more descriptive error for fetch_crl tests