### PR TITLE
Fix cleanup failures when using osg-update-data (since it depends on osg-release)

### DIFF
--- a/osgtest/library/files.py
+++ b/osgtest/library/files.py
@@ -219,6 +219,7 @@ def restore(path, owner, ignore_missing=False):
 
 def remove(path, force=False):
     """Remove the path, which could be a file, symlink, empty directory, or file glob.
+    Does nothing if the path is already missing.
 
     If the force argument is True, then this function will remove non-empty directories.
     """

--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -71,14 +71,14 @@ class TestInstall(osgunittest.OSGTestCase):
 
         self.skip_bad_unless(core.state['install.success'], 'Install did not succeed')
 
-        command = ['rpm', '-e', 'osg-release']
+        command = ['rpm', '-e', '--nodeps', 'osg-release']
         core.check_system(command, 'Erase osg-release')
 
         self.assert_(re.match('\d+\.\d+', core.options.updaterelease), "Unrecognized updaterelease format")
         rpm_url = 'https://repo.opensciencegrid.org/osg/' + core.options.updaterelease + '/osg-' + \
                   core.options.updaterelease + '-el' + str(core.el_release()) + '-release-latest.rpm'
-        command = ['rpm', '-Uvh', rpm_url]
-        core.check_system(command, 'Update osg-release')
+        command = ['yum', 'install', '-y', rpm_url]
+        core.check_system(command, 'Install new version of osg-release')
 
         core.config['yum.clean_repos'] = ['osg'] + core.options.updaterepos
         yum.clean(*core.config['yum.clean_repos'])


### PR DESCRIPTION
(orig. title was "Do not erase osg-release before upgrading")
It is not necessary and breaks packages that depend on osg-release like osg-update-vos.