### PR TITLE
mod_auth_oidc is now available in appstream on EL8/9 (SOFTWARE-5679)

### DIFF
--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -37,11 +37,6 @@ class TestInstall(osgunittest.OSGTestCase):
                 pkg_repo_dict["x509-scitokens-issuer-client"] = ["osg-development"]
                 break
 
-        # Special case: htcondor-ce-collector on EL8 needs mod_auth_oidc, only avaiable in a module
-        if "htcondor-ce-collector" in pkg_repo_dict:
-            if core.el_release() > 7:
-                core.check_system(["dnf", "-y", "module", "enable", "mod_auth_openidc"], "Enable mod_auth_openidc module")
-
         for pkg, repos in pkg_repo_dict.items():
             # Do not try to re-install packages
             if core.rpm_is_installed(pkg):


### PR DESCRIPTION
This was causing EL9 test failures for the central collector:

- Before: https://osg-sw-submit.chtc.wisc.edu/tests/20230921-1431/results.html
- After: https://osg-sw-submit.chtc.wisc.edu/tests/20230921-1736/results.html