### PR TITLE
Get stashcp tests working with Pelican

### DIFF
--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -145,7 +145,7 @@ class TestStartStashCache(OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
-                                      "stashcache-client",
+                                      "osdf-client",
                                       by_dependency=True)
 
     def test_01_configure(self):

--- a/osgtest/tests/test_835_stashcache.py
+++ b/osgtest/tests/test_835_stashcache.py
@@ -28,7 +28,7 @@ class TestStopStashCache(OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
-                                      "stashcache-client",
+                                      "osdf-client",
                                       by_dependency=True)
 
     def test_01_stop_stash_origin(self):

--- a/travis-ci/stashcache.packages
+++ b/travis-ci/stashcache.packages
@@ -1,4 +1,4 @@
-stashcache-client
+osdf-client
 stash-cache
 stash-origin
 gfal2-all


### PR DESCRIPTION
- The `pelican-osdf-compat` RPM doesn't provide the `stashcache-client` virtual dependency; it's a very old name (used for the Python version of `stashcp`) so check for the `osdf-client` virtual dependency instead when deciding whether to skip the `stashcp` test or not

- Pelican uses `STASH_TOPOLOGY_NAMESPACE_URL` instead of `STASH_NAMESPACE_URL` for the URL to the namespaces JSON; set both in the environment so old and new versions of `stashcp` work as expected

- Better detect if we're using a Go version of `stashcp` (and should pass `--cache` instead of editing `caches.json`)