### PR TITLE
Require "stashcp" for stashcp tests (SOFTWARE-5812)

### DIFF
--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -145,7 +145,7 @@ class TestStartStashCache(OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
-                                      "osdf-client",
+                                      "stashcp",
                                       by_dependency=True)
 
     def test_01_configure(self):

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -41,7 +41,7 @@ class TestStashCache(OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
-                                      "osdf-client",
+                                      "stashcp",
                                       by_dependency=True)
         self.skip_bad_unless_running("xrootd@stash-origin", "xrootd@stash-cache", "xrootd@stash-origin-auth",
                                      "xrootd@stash-cache-auth")

--- a/osgtest/tests/test_835_stashcache.py
+++ b/osgtest/tests/test_835_stashcache.py
@@ -28,7 +28,7 @@ class TestStopStashCache(OSGTestCase):
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
-                                      "osdf-client",
+                                      "stashcp",
                                       by_dependency=True)
 
     def test_01_stop_stash_origin(self):

--- a/travis-ci/stashcache.packages
+++ b/travis-ci/stashcache.packages
@@ -1,4 +1,4 @@
-osdf-client
+stashcp
 stash-cache
 stash-origin
 gfal2-all


### PR DESCRIPTION
The dependency "osdf-client" is not available, except in 23-upcoming.

VMU run: https://osg-sw-submit.chtc.wisc.edu/tests/20240207-1110/packages.html. A spot check showed that the various "stashcache" tests are no longer getting skipped in the XCache test set.