### PR TITLE
Set STASH_USE_TOPOLOGY for stashcp tests for Pelican 7.5.0+ compat

### DIFF
--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -103,7 +103,8 @@ class TestStashCache(OSGTestCase):
         stash_namespace_url = getcfg("STASH_NAMESPACE_URL")
         with tempfile.NamedTemporaryFile(mode="r+b") as tf:
             with core.environ_context({"STASH_NAMESPACE_URL": stash_namespace_url,
-                                       "STASH_TOPOLOGY_NAMESPACE_URL": stash_namespace_url}):
+                                       "STASH_TOPOLOGY_NAMESPACE_URL": stash_namespace_url,
+                                       "STASH_USE_TOPOLOGY": "1"}):
                 core.check_system(command + [path, tf.name],
                                   "Checking stashcp")
             result = tf.read()


### PR DESCRIPTION
Pelican 7.5.0+ talks to the Director by default, not Topology, so the fake Topology server we're setting up in the tests gets bypassed. Setting STASH_USE_TOPOLOGY to non-blank makes it fall back to the previous behavior.

https://osg-sw-submit.chtc.wisc.edu/tests/20240208-1718/packages.html