### PR TITLE
Fix scitokens debug level

### DIFF
--- a/osgtest/tests/test_150_xrootd.py
+++ b/osgtest/tests/test_150_xrootd.py
@@ -49,7 +49,7 @@ ofs.trace all
 http.trace all
 voms.trace all
 sec.trace all
-scitokens.trace debug
+scitokens.trace all
 """
 
 SCITOKENS_CONF_TEXT = f"""\


### PR DESCRIPTION
`scitokens.trace debug` only turned on 'debug' messages, not 'error', 'warning', and 'info'