### PR TITLE
Add 2X-main special casing to install

### DIFF
--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -15,7 +15,11 @@ class TestInstall(osgunittest.OSGTestCase):
             core.check_system(pre + ('osg-release',), 'Verify osg-release')
         except AssertionError:
             core.check_system(pre + ('osg-release-itb',), 'Verify osg-release + osg-release-itb')
-        core.config['install.original-release-ver'] = core.osg_release().version
+        
+        original_release = core.osg_release().version
+        if '.' not in original_release:  # 23, 24, etc.
+            original_release = f'{original_release}-main'
+        core.config['install.original-release-ver'] = original_release
 
     def test_02_install_packages(self):
         core.state['install.success'] = False


### PR DESCRIPTION
- Code to convert `23` to `23-main` already existed in the "upgrade" logic, but was missing from the "downgrade" logic
- It might make more sense to remove the special casing and switch the parameters.d/*.yaml files to include `-main`, this might have wider code ramifications though
  - eg. `sources: [opensciencegrid:main; 23-main; osg, osg-upcoming > 24/osg-minefield]`


Successful test run using this patch: https://osg-sw-submit.chtc.wisc.edu/tests/20241024-1623/results.html