### PR TITLE
Skip StashCache tests if pelican is installed

### DIFF
--- a/osgtest/tests/test_155_stashcache.py
+++ b/osgtest/tests/test_155_stashcache.py
@@ -145,11 +145,14 @@ def start_xrootd(instance):
 
 
 class TestStartStashCache(OSGTestCase):
+    @core.osgrelease(23)
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
                                       "stashcp",
                                       by_dependency=True)
+        if core.rpm_is_installed("pelican"):
+            self.skip_ok("pelican is installed, skipping stashcache tests")
 
     def test_01_configure(self):
         caching_plugin_cfg_path = "/etc/xrootd/config.d/40-stash-cache-plugin.cfg"

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -38,11 +38,14 @@ class TestStashCache(OSGTestCase):
                                 expected=contents,
                                 message="cached file %s mismatch" % name)
 
+    @core.osgrelease(23)
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
                                       "stashcp",
                                       by_dependency=True)
+        if core.rpm_is_installed("pelican"):
+            self.skip_ok("pelican is installed, skipping stashcache tests")
         self.skip_bad_unless_running("xrootd@stash-origin", "xrootd@stash-cache", "xrootd@stash-origin-auth",
                                      "xrootd@stash-cache-auth")
 

--- a/osgtest/tests/test_835_stashcache.py
+++ b/osgtest/tests/test_835_stashcache.py
@@ -25,11 +25,14 @@ def stop_xrootd(instance):
 
 
 class TestStopStashCache(OSGTestCase):
+    @core.osgrelease(23)
     def setUp(self):
         core.skip_ok_unless_installed("stash-origin",
                                       "stash-cache",
                                       "stashcp",
                                       by_dependency=True)
+        if core.rpm_is_installed("pelican"):
+            self.skip_ok("pelican is installed, skipping stashcache tests")
 
     def test_01_stop_stash_origin(self):
         stop_xrootd("stash-origin")


### PR DESCRIPTION
"stash-cache" and "stash-origin" are deprecated (and have been removed in 24-main),
and the "pelican" command-line tool does not work with the osg-test
stashcache setup because it uses a director instead of topology.

At some point, separate tests for pelican should be added.
