### PR TITLE
SOFTWARE-6152: reorder cert generation

### DIFF
--- a/files/test_sequence
+++ b/files/test_sequence
@@ -3,6 +3,7 @@ test_050_mysqld
 test_055_osg_ca_manage
 test_060_fetch_crl
 test_070_munge
+test_080_certs
 test_090_jobs
 test_100_condor
 test_150_xrootd

--- a/osg-test
+++ b/osg-test
@@ -178,8 +178,7 @@ def discover_tests():
     test_files = ['osgtest.tests.' + test for test in test_sequence_lines if test and not test.startswith('#')]
     test_sequence.close()
     # prepend tests that are always safe
-    args = ['osgtest.tests.special_certs',
-            'osgtest.tests.special_user',
+    args = ['osgtest.tests.special_user',
             'osgtest.tests.special_selinux']
     if len(core.options.packages) > 0:
         args.append('osgtest.tests.special_install')

--- a/osgtest/tests/special_user.py
+++ b/osgtest/tests/special_user.py
@@ -3,9 +3,7 @@ import os
 import random
 
 import osgtest.library.core as core
-import osgtest.library.files as files
 import osgtest.library.osgunittest as osgunittest
-from cagen import CA, certificate_info
 import pwd
 
 
@@ -89,31 +87,3 @@ class TestUser(osgunittest.OSGTestCase):
 
         core.state['user.verified'] = True
 
-    def test_03_generate_user_cert(self):
-        core.state['general.user_cert_created'] = False
-        core.state['system.wrote_mapfile'] = False
-
-        if core.options.skiptests:
-            core.skip('no user needed')
-            return
-
-        self.skip_bad_unless(core.state['user.verified'], "User doesn't exist, has HOME=/, or is missing HOME")
-
-        # Set up certificate
-        globus_dir = os.path.join(core.state['user.pwd'].pw_dir, '.globus')
-        core.state['user.cert_path'] = os.path.join(globus_dir, 'usercert.pem')
-        core.state['user.key_path'] = os.path.join(globus_dir, 'userkey.pem')
-        test_ca = CA.load(core.config['certs.test-ca'])
-        if not os.path.exists(core.state['user.cert_path']):
-            test_ca.usercert(core.options.username, core.options.password)
-            core.state['general.user_cert_created'] = True
-
-        (core.config['user.cert_subject'],
-         core.config['user.cert_issuer']) = certificate_info(core.state['user.cert_path'])
-
-        # Add user to mapfile
-        files.append(core.config['system.mapfile'], '"%s" %s\n' %
-                     (core.config['user.cert_subject'], core.state['user.pwd'].pw_name),
-                     owner='user')
-        core.state['system.wrote_mapfile'] = True
-        os.chmod(core.config['system.mapfile'], 0o644)

--- a/osgtest/tests/test_080_certs.py
+++ b/osgtest/tests/test_080_certs.py
@@ -2,6 +2,7 @@ import os
 import osgtest.library.core as core
 from cagen import CA
 import osgtest.library.osgunittest as osgunittest
+from osgtest.library.voms import VONAME
 
 class TestCert(osgunittest.OSGTestCase):
 
@@ -24,5 +25,6 @@ class TestCert(osgunittest.OSGTestCase):
         if core.options.hostcert and not os.path.exists(core.config['certs.hostcert']):
             test_ca = CA.load(core.config['certs.test-ca'])
             test_ca.hostcert()
+            test_ca.voms(VONAME)
             core.state['certs.hostcert_created'] = True
 


### PR DESCRIPTION
Move `special_certs.py` to `test_080_certs.py` to circumvent an issue with the test cert getting overwritten prior to being used by `test_055_osg_ca_manage.py:test_01_setup_ca`