### PR TITLE
SOFTWARE-6174: HTvault tests

### DIFF
--- a/files/test_sequence
+++ b/files/test_sequence
@@ -36,4 +36,4 @@ test_910_pbs
 test_940_munge
 test_950_mysqld
 test_970_java
-test_980_htvault
+test_295_htvault

--- a/files/test_sequence
+++ b/files/test_sequence
@@ -36,3 +36,4 @@ test_910_pbs
 test_940_munge
 test_950_mysqld
 test_970_java
+test_980_htvault

--- a/files/test_sequence
+++ b/files/test_sequence
@@ -14,6 +14,7 @@ test_180_cvmfs
 test_190_condorce
 test_200_voms
 test_290_slurm
+test_295_htvault
 test_380_cvmfs
 test_401_scitokens
 test_407_voms
@@ -36,4 +37,4 @@ test_910_pbs
 test_940_munge
 test_950_mysqld
 test_970_java
-test_295_htvault
+test_980_htvault

--- a/osgtest/tests/test_980_htvault.py
+++ b/osgtest/tests/test_980_htvault.py
@@ -1,4 +1,3 @@
-import re
 from os.path import join
 
 import osgtest.library.core as core
@@ -33,7 +32,7 @@ class TestStartHTVault(osgunittest.OSGTestCase):
         core.state['vault.started-service'] = False
         core.state['vault.running-service'] = False
 
-        core.skip_ok_unless_installed('htvault', 'htgettoken')
+        core.skip_ok_unless_installed('htvault-config', 'htgettoken')
 
         core.config['vault.config-dir'] = '/etc/htvault-config/config.d/'
 
@@ -65,6 +64,10 @@ class TestStartHTVault(osgunittest.OSGTestCase):
             '-days', '365',
             '-nodes',
             '-subj', '/C=US/ST=WI/L=Madison/O=UW/OU=CHTC/CN=TestVault'))
+        # Need to set ownership of certs
+        core.system((
+            'chown', 'vault', '/etc/htvault-config/hostkey.pem', '/etc/htvault-config/hostcert.pem'
+        ))
 
         service.check_start('vault')
         # htvault-config depends on vault and should be started automatically

--- a/osgtest/tests/test_980_htvault.py
+++ b/osgtest/tests/test_980_htvault.py
@@ -43,10 +43,10 @@ class TestStartHTVault(osgunittest.OSGTestCase):
 
         # Pre-configure HTVault: Create Yaml config files for vault's (dummy) identity provider
         core.config['vault.issuer-config'] = join(core.config['vault.config-dir'], '20-cilogon.yaml')
-        files.write(core.config['vault.issuer-config'], HTVAULT_ISSUER_CONFIG, owner='vault', chmod=0o644)
+        files.write(core.config['vault.issuer-config'], HTVAULT_ISSUER_CONFIG, owner='vault', chmod=0o644, backup=False)
 
         core.config['vault.secrets-config'] = join(core.config['vault.config-dir'], '80-secrets.yaml')
-        files.write(core.config['vault.secrets-config'], HTVAULT_SECRET_CONFIG, owner='vault', chmod=0o644)
+        files.write(core.config['vault.secrets-config'], HTVAULT_SECRET_CONFIG, owner='vault', chmod=0o644, backup=False)
 
 
         # TODO are there existing libraries within the test framework to support this? Cagen doesn't seem

--- a/osgtest/tests/test_980_htvault.py
+++ b/osgtest/tests/test_980_htvault.py
@@ -1,0 +1,34 @@
+from os.path import join
+
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.condor as condor
+import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+
+class TestStopHTVault(osgunittest.OSGTestCase):
+
+    def test_01_stop_htvault(self):
+        """ Shut down the vault instance set up in the startup test and
+        clean up config files 
+        """
+
+        # Check that the vault (and htvault) services were started successfully
+        if not (service.is_running('vault') and service.is_running('htvault-config')):
+            core.state['vault.running-service'] = False
+            return
+
+        # Attempt to stop the vault and htvault-config services
+        service.check_stop('htvault-config')
+        service.check_stop('vault')
+
+        core.state['vault.running-service'] = False
+
+        # Clean up the files created for the htvault-config test
+        files.remove(core.config['vault.issuer-config'])
+        files.remove(core.config['vault.secrets-config'])
+        files.remove(core.config['vault.hostcert'])
+        files.remove(core.config['vault.hostkey'])
+        
+
+

--- a/osgtest/tests/test_980_htvault.py
+++ b/osgtest/tests/test_980_htvault.py
@@ -37,17 +37,39 @@ class TestStartHTVault(osgunittest.OSGTestCase):
 
         core.config['vault.config-dir'] = '/etc/htvault-config/config.d/'
 
+        # Check that the vault (and htvault) services aren't already running
         if service.is_running('vault'):
             core.state['vault.running-service'] = True
             return
 
+        # Pre-configure HTVault: Create Yaml config files for vault's (dummy) identity provider
         core.config['vault.issuer-config'] = join(core.config['vault.config-dir'], '20-cilogon.yaml')
         files.write(core.config['vault.issuer-config'], HTVAULT_ISSUER_CONFIG, owner='vault', chmod=0o644)
 
         core.config['vault.secrets-config'] = join(core.config['vault.config-dir'], '80-secrets.yaml')
         files.write(core.config['vault.secrets-config'], HTVAULT_SECRET_CONFIG, owner='vault', chmod=0o644)
 
+
+        # TODO are there existing libraries within the test framework to support this? Cagen doesn't seem
+        # to support exactly this
+
+        # Create a cert/key pair for vault
+        core.system((
+            'openssl', 
+            'req', 
+            '-x509', 
+            '-newkey', 'rsa:4096', 
+            '-keyout', '/etc/htvault-config/hostkey.pem', 
+            '-out', '/etc/htvault-config/hostcert.pem',
+            '-sha256',
+            '-days', '365',
+            '-nodes',
+            '-subj', '/C=US/ST=WI/L=Madison/O=UW/OU=CHTC/CN=CommonNameOrHostname'))
+
         service.check_start('vault')
+        # htvault-config depends on vault and should be started automatically
+        service.check_start('htvault-config')
+
         core.state['vault.started-service'] = True
         core.state['vault.running-service'] = True
 

--- a/osgtest/tests/test_980_htvault.py
+++ b/osgtest/tests/test_980_htvault.py
@@ -64,7 +64,7 @@ class TestStartHTVault(osgunittest.OSGTestCase):
             '-sha256',
             '-days', '365',
             '-nodes',
-            '-subj', '/C=US/ST=WI/L=Madison/O=UW/OU=CHTC/CN=CommonNameOrHostname'))
+            '-subj', '/C=US/ST=WI/L=Madison/O=UW/OU=CHTC/CN=TestVault'))
 
         service.check_start('vault')
         # htvault-config depends on vault and should be started automatically

--- a/osgtest/tests/test_980_htvault.py
+++ b/osgtest/tests/test_980_htvault.py
@@ -1,0 +1,53 @@
+import re
+from os.path import join
+
+import osgtest.library.core as core
+import osgtest.library.files as files
+import osgtest.library.condor as condor
+import osgtest.library.osgunittest as osgunittest
+import osgtest.library.service as service
+
+HTVAULT_ISSUER_CONFIG = '''
+issuers:
+  - name: cilogon
+    clientid: xxx
+    url: https://cilogon.org
+    callbackmode: direct
+    credclaim: wlcg.credkey
+    roles:
+      - name: default
+        scopes: [profile,email,org.cilogon.userinfo,storage.read:,storage.create:]
+      - name: readonly
+        scopes: [profile,email,org.cilogon.userinfo,storage.read:]
+'''
+
+HTVAULT_SECRET_CONFIG = '''
+issuers:
+  - name: cilogon
+    secret: xxx
+'''
+
+class TestStartHTVault(osgunittest.OSGTestCase):
+
+    def test_01_start_htvault(self):
+        core.state['vault.started-service'] = False
+        core.state['vault.running-service'] = False
+
+        core.skip_ok_unless_installed('htvault', 'htgettoken')
+
+        core.config['vault.config-dir'] = '/etc/htvault-config/config.d/'
+
+        if service.is_running('vault'):
+            core.state['vault.running-service'] = True
+            return
+
+        core.config['vault.issuer-config'] = join(core.config['vault.config-dir'], '20-cilogon.yaml')
+        files.write(core.config['vault.issuer-config'], HTVAULT_ISSUER_CONFIG, owner='vault', chmod=0o644)
+
+        core.config['vault.secrets-config'] = join(core.config['vault.config-dir'], '80-secrets.yaml')
+        files.write(core.config['vault.secrets-config'], HTVAULT_SECRET_CONFIG, owner='vault', chmod=0o644)
+
+        service.check_start('vault')
+        core.state['vault.started-service'] = True
+        core.state['vault.running-service'] = True
+


### PR DESCRIPTION
Basic "install and start" VMU test for HTVault. Creates the necessary config files and key pair then attempts to start the systemd service. Has been tested once: https://osg-sw-submit.chtc.wisc.edu/tests/20250730-1140/results.html