### PR TITLE
Flip daemon-user switch logic

### DIFF
--- a/osgtest/tests/test_295_htvault.py
+++ b/osgtest/tests/test_295_htvault.py
@@ -42,12 +42,12 @@ class TestStartHTVault(osgunittest.OSGTestCase):
         core.config['vault.config-dir'] = '/etc/htvault-config/config.d/'
 
         # Daemon user changed from vault to openbao in htvault-config 2.1.0, accomodate both        
-        daemon_user = 'vault'
+        daemon_user = 'openbao'
         try:
             # Sample command that will fail if the daemon user doesn't exist
             pwd.getpwnam(daemon_user)
         except KeyError:
-            daemon_user = 'openbao'
+            daemon_user = 'vault'
 
 
         # Check that the vault (and htvault) services aren't already running


### PR DESCRIPTION
In the release -> minefield tests, the release version creates the `vault` user then the minefield version creates the `openbao` user, which caused the daemon user check to incorrectly select the `vault` user. Flip the logic so that `openbao` will be chosen as long as the `openbao` user exists.