### PR TITLE
Replace deprecated `assert_` with `assertTrue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Within each test function, use the [TestCase object functions](http://docs.pytho
 ```python
 def test_99_example(self):
      result = do_something()
-     self.assert_(result > 42, 'result too low')
+     self.assertTrue(result > 42, 'result too low')
      self.assertEqual(result, 57, 'result ok')
 ```
 
@@ -343,7 +343,7 @@ def test_01_web100clt(self):
     command = ('web100clt', '-v')
     stdout, stderr, fail = core.check_system(command, 'NDT client')
     result = re.search('ndt.+version', stdout, re.IGNORECASE)
-    self.assert_(result is not None)
+    self.assertTrue(result is not None)
 ```
 
 ### Configuration and State

--- a/osgtest/tests/special_install.py
+++ b/osgtest/tests/special_install.py
@@ -74,7 +74,7 @@ class TestInstall(osgunittest.OSGTestCase):
         core.check_system(command, 'Erase osg-release')
 
         update_release = core.options.updaterelease
-        self.assert_(re.match(r'\d+[.]?\d+$', update_release), "Unrecognized updaterelease format")
+        self.assertTrue(re.match(r'\d+[.]?\d+$', update_release), "Unrecognized updaterelease format")
 
         # Example URLs
         # https://repo.opensciencegrid.org/osg/3.6/osg-3.6-el7-release-latest.rpm
@@ -127,4 +127,3 @@ def verify_dependency(dep):
 
     command = ('rpm', '--verify', pkg)
     core.check_system(command, 'Verify %s' % pkg)
-

--- a/osgtest/tests/test_040_java.py
+++ b/osgtest/tests/test_040_java.py
@@ -14,7 +14,7 @@ class TestJava(osgunittest.OSGTestCase):
     def _select_alternatives(self, config_type):
         core.config['java.old-ver'][config_type] = java.get_ver(config_type)
         java.select_ver(config_type, '%s-openjdk' % java.EXPECTED_VERSION)
-        self.assert_(java.verify_ver(config_type, java.EXPECTED_VERSION), 'incorrect java version selected')
+        self.assertTrue(java.verify_ver(config_type, java.EXPECTED_VERSION), 'incorrect java version selected')
 
     def test_00_setup(self):
         if java.is_openjdk_installed() or java.is_openjdk_devel_installed():

--- a/osgtest/tests/test_050_mysqld.py
+++ b/osgtest/tests/test_050_mysqld.py
@@ -20,12 +20,12 @@ class TestStartMySQL(osgunittest.OSGTestCase):
         command = ('mysql', '-sNe', "SHOW VARIABLES where Variable_name='datadir';")
         mysql_cfg = core.check_system(command, 'dump mysql config')[0]
         core.config['mysql.datadir'] = re.match(r'datadir\s*(.+?)/\s*$', mysql_cfg).group(1)
-        self.assert_(core.config['mysql.datadir'] is not None, 'could not extract MySQL datadir')
+        self.assertTrue(core.config['mysql.datadir'] is not None, 'could not extract MySQL datadir')
 
         # Backup the old mysql folder
         mysql.stop()
         backup = core.config['mysql.datadir'] + '-backup'
-        self.assert_(not os.path.exists(backup), 'mysql-backup already exists')
+        self.assertTrue(not os.path.exists(backup), 'mysql-backup already exists')
         try:
             shutil.move(core.config['mysql.datadir'], backup)
         except IOError as e:

--- a/osgtest/tests/test_055_osg_ca_manage.py
+++ b/osgtest/tests/test_055_osg_ca_manage.py
@@ -16,7 +16,7 @@ class TestOsgCaManage(osgunittest.OSGTestCase):
 
         self.assertEquals(status, 0, fail)
         pem_count = len(glob.glob('/etc/grid-security/certificates/*.pem'))
-        self.assert_(pem_count > 0, "No certificates installed")
+        self.assertTrue(pem_count > 0, "No certificates installed")
 
     def test_02_verify_ca(self):
         """Verify CA installation via `osg-ca-manage verify`"""

--- a/osgtest/tests/test_060_fetch_crl.py
+++ b/osgtest/tests/test_060_fetch_crl.py
@@ -51,11 +51,11 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         status, stdout, stderr = core.system(command)
         fail = core.diagnose('Run %s in /etc' % 'fetch-crl', command, status, stdout, stderr)
         if status == 1:
-            self.assert_(output_is_acceptable(stdout), fail)
+            self.assertTrue(output_is_acceptable(stdout), fail)
         else:
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join('/etc/grid-security/certificates', '*.r[0-9]')))
-        self.assert_(count > 3, f"Expected > 3 crls but found {count}")
+        self.assertTrue(count > 3, f"Expected > 3 crls but found {count}")
 
     def test_02_fetch_crl_dir(self):
         core.skip_ok_unless_installed('fetch-crl')
@@ -68,9 +68,9 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         status, stdout, stderr = core.system(command)
         fail = core.diagnose('Run fetch-crl in temp dir', command, status, stdout, stderr)
         if status == 1:
-            self.assert_(output_is_acceptable(stdout), fail)
+            self.assertTrue(output_is_acceptable(stdout), fail)
         else:
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join(temp_crl_dir, '*.r[0-9]')))
         shutil.rmtree(temp_crl_dir)
-        self.assert_(count > 3, f"Expected > 3 crls but found {count}")
+        self.assertTrue(count > 3, f"Expected > 3 crls but found {count}")

--- a/osgtest/tests/test_070_munge.py
+++ b/osgtest/tests/test_070_munge.py
@@ -14,5 +14,5 @@ class TestStartMunge(osgunittest.OSGTestCase):
         files.preserve(core.config['munge.keyfile'], 'munge')
         command = ('/usr/sbin/create-munge-key', '-f',)
         stdout, _, fail = core.check_system(command, 'Create munge key')
-        self.assert_(stdout.find('error') == -1, fail)
+        self.assertTrue(stdout.find('error') == -1, fail)
         service.check_start('munge')

--- a/osgtest/tests/test_170_pbs.py
+++ b/osgtest/tests/test_170_pbs.py
@@ -75,7 +75,7 @@ set server acl_host_enable = True
             command = ('/usr/sbin/pbs_server -d /var/lib/torque -t create -f && '
                        'sleep 10 && /usr/bin/qterm')
             stdout, _, fail = core.check_system(command, 'create initial pbs serverdb config', shell=True)
-            self.assert_(stdout.find('error') == -1, fail)
+            self.assertTrue(stdout.find('error') == -1, fail)
 
         # This gets wiped if we write it before the initial 'service pbs_server create'
         # However, this file needs to be in place before the service is started so we
@@ -111,10 +111,9 @@ set server acl_host_enable = True
         while (time.time() - start_time) < 600:
             command = ('/usr/bin/qnodes', '-s', core.get_hostname())
             stdout, _, fail = core.check_system(command, 'Get pbs node info')
-            self.assert_(stdout.find('error') == -1, fail)
+            self.assertTrue(stdout.find('error') == -1, fail)
             if stdout.find('state = free'):
                 core.state['torque.nodes-up'] = True
                 break
         if not core.state['torque.nodes-up']:
             self.fail('PBS nodes not coming up')
-

--- a/osgtest/tests/test_380_cvmfs.py
+++ b/osgtest/tests/test_380_cvmfs.py
@@ -77,7 +77,7 @@ class TestCvmfs(osgunittest.OSGTestCase):
         command = ('ls', '/cvmfs')
         status, stdout, stderr = core.system(command, False)
         file_exists = os.path.exists('/cvmfs')
-        self.assert_(file_exists, 'Cvmfs mount point missing')
+        self.assertTrue(file_exists, 'Cvmfs mount point missing')
         core.state['cvmfs.mounted'] = True
 
         cern_repo = 'cms.cern.ch'
@@ -90,7 +90,7 @@ class TestCvmfs(osgunittest.OSGTestCase):
 
         command = ('ls', self.__check_path)
         status, stdout, stderr = core.system(command, False)
-        self.assert_(file_exists, 'Test cvmfs file missing')
+        self.assertTrue(file_exists, 'Test cvmfs file missing')
 
         command = ('bash', '-c', 'source ' + self.__check_path)
         status, stdout, stderr = core.system(command, False)

--- a/osgtest/tests/test_407_voms.py
+++ b/osgtest/tests/test_407_voms.py
@@ -17,7 +17,7 @@ class TestVOMS(osgunittest.OSGTestCase):
 
         command = ('voms-proxy-info', '-all')
         stdout = core.check_system(command, 'Run voms-proxy-info', user=True)[0]
-        self.assert_(('/%s/Role=NULL' % (core.config['voms.vo'])) in stdout, msg)
+        self.assertTrue(('/%s/Role=NULL' % (core.config['voms.vo'])) in stdout, msg)
 
     def test_00_setup(self):
         core.state.setdefault('proxy.valid', False)
@@ -56,7 +56,7 @@ class TestVOMS(osgunittest.OSGTestCase):
         password = core.options.password + '\n'
         status, stdout, _ = core.system(command, True, password)
         self.assertNotEqual(status, 0, 'voms-proxy-init fails on bad group')
-        self.assert_('Unable to satisfy' in stdout, 'voms-proxy-init failure message')
+        self.assertTrue('Unable to satisfy' in stdout, 'voms-proxy-init failure message')
 
     # Copy of 03 above, to make sure failure did not affect good proxy
     def test_05_voms_proxy_info(self):

--- a/osgtest/tests/test_450_xrootd.py
+++ b/osgtest/tests/test_450_xrootd.py
@@ -114,7 +114,7 @@ class TestXrootd(osgunittest.OSGTestCase):
         command = ('xrdcp', '--debug', '2', TestXrootd.__data_path, xroot_url(TestXrootd.user_copied_file_gsi))
         with core.no_bearer_token(core.options.username):
             core.check_system(command, "xrdcp upload to user dir with GSI auth", user=True)
-        self.assert_(os.path.exists(TestXrootd.user_copied_file_gsi), "Uploaded file missing")
+        self.assertTrue(os.path.exists(TestXrootd.user_copied_file_gsi), "Uploaded file missing")
 
     @xrootd_record_failure
     def test_03b_xrdcp_upload_scitoken_authenticated(self):
@@ -139,7 +139,7 @@ class TestXrootd(osgunittest.OSGTestCase):
                 core.check_system(command, message, exit=expected_exit, user=True)
 
             # TODO: Test token discovery at $X509_RUNTIME_DIR/bt_u$UID and /tmp/bt_u$UID
-        self.assert_(os.path.exists(TestXrootd.user_copied_file_scitoken), "Uploaded file missing")
+        self.assertTrue(os.path.exists(TestXrootd.user_copied_file_scitoken), "Uploaded file missing")
 
     @xrootd_record_failure
     def test_03c_xrdcp_upload_voms_authenticated(self):
@@ -148,7 +148,7 @@ class TestXrootd(osgunittest.OSGTestCase):
         command = ('xrdcp', '--force', '--debug', '2', TestXrootd.__data_path, xrootd_url)
         with core.no_bearer_token(core.options.username):
             core.check_system(command, "xrdcp upload to vo dir with VOMS auth", user=True)
-        self.assert_(os.path.exists(TestXrootd.vo_copied_file), "Uploaded file missing")
+        self.assertTrue(os.path.exists(TestXrootd.vo_copied_file), "Uploaded file missing")
 
     @xrootd_record_failure
     def test_04a_xrdcp_upload_gsi_authenticated_denied(self):
@@ -205,7 +205,7 @@ class TestXrootd(osgunittest.OSGTestCase):
         files.remove(TestXrootd.download_temp)
         try:
             core.check_system(command, message ,user=True)
-            self.assert_(os.path.isfile(TestXrootd.download_temp), "Downloaded file missing")
+            self.assertTrue(os.path.isfile(TestXrootd.download_temp), "Downloaded file missing")
             self.assertEqualVerbose(files.read(TestXrootd.download_temp, as_single_string=True),
                                     files.read(remote_file, as_single_string=True),
                                     "Downloaded contents differ from expected")

--- a/osgtest/tests/test_460_stashcache.py
+++ b/osgtest/tests/test_460_stashcache.py
@@ -128,7 +128,7 @@ class TestStashCache(OSGTestCase):
                                          "Checking xrootd copy from authenticated origin", user=True)
         origin_file = os.path.join(getcfg("OriginRootdir"), getcfg("OriginAuthExport").lstrip("/"), name)
         checksum_match = files.checksum_files_match(origin_file, dest_file)
-        self.assert_(checksum_match, 'Origin and directly downloaded file have the same contents')
+        self.assertTrue(checksum_match, 'Origin and directly downloaded file have the same contents')
 
     def test_07_xrootd_fetch_from_auth_cache(self):
         # TODO This should work with voms certs too
@@ -144,7 +144,7 @@ class TestStashCache(OSGTestCase):
                                dest_file], "Checking xrootd copy from Authenticated cache", user=True)
         origin_file = os.path.join(getcfg("OriginRootdir"), getcfg("OriginAuthExport").lstrip("/"), name)
         checksum_match = files.checksum_files_match(origin_file, dest_file)
-        self.assert_(checksum_match, 'Origin and file downloaded via cache have the same contents')
+        self.assertTrue(checksum_match, 'Origin and file downloaded via cache have the same contents')
 
     def test_08_https_fetch_from_auth_cache(self):
         # TODO This should work with voms certs too
@@ -166,4 +166,4 @@ class TestStashCache(OSGTestCase):
                               "Checking xrootd copy from Authenticated cache", user=True)
         origin_file = os.path.join(getcfg("OriginRootdir"), getcfg("OriginAuthExport").lstrip("/"), name)
         checksum_match = files.checksum_files_match(origin_file, dest_file)
-        self.assert_(checksum_match, 'Origin and file downloaded via cache have the same contents')
+        self.assertTrue(checksum_match, 'Origin and file downloaded via cache have the same contents')

--- a/osgtest/tests/test_580_gfal2util.py
+++ b/osgtest/tests/test_580_gfal2util.py
@@ -32,17 +32,17 @@ class TestGFAL2Util(osgunittest.OSGTestCase):
          command = ('gfal-copy', '-v', '-f', self.get_gftp_url_base() + TestGFAL2Util.__data_path, 'file://' + TestGFAL2Util.__local_path)
          core.check_system(command, "gfal2-util copy from  GridFTP URL to local", user='vdttest')
          file_copied = os.path.exists(TestGFAL2Util.__local_path)
-         self.assert_(file_copied, 'Copied file missing')
+         self.assertTrue(file_copied, 'Copied file missing')
 
     def test_02_copy_local_to_server_gfal2_util(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'gfal2-plugin-gridftp')
         self.skip_ok_unless(core.state['gridftp.running-server'], 'gridftp server not running')
         file_not_created = not os.path.exists(TestGFAL2Util.__remote_path)
-        self.assert_(file_not_created, 'to be copied files does not exist')
+        self.assertTrue(file_not_created, 'to be copied files does not exist')
         command = ('gfal-copy', '-v', 'file://' + TestGFAL2Util.__local_path, self.get_gftp_url_base() + TestGFAL2Util.__remote_path)
         core.check_system(command, "gfal2-util copy from  local to GridFTP URL", user='vdttest')
         file_copied = os.path.exists(TestGFAL2Util.__remote_path)
-        self.assert_(file_copied, 'Copied file missing')
+        self.assertTrue(file_copied, 'Copied file missing')
 
     def test_03_remove_server_file_gfal2_util_gftp(self):
         core.skip_ok_unless_installed('globus-gridftp-server-progs', 'gfal2-plugin-gridftp')
@@ -50,6 +50,6 @@ class TestGFAL2Util(osgunittest.OSGTestCase):
         command = ('gfal-rm', '-v', self.get_gftp_url_base() + TestGFAL2Util.__remote_path)
         core.check_system(command, "gfal2-util remove, URL file", user='vdttest')
         file_removed = not os.path.exists(TestGFAL2Util.__remote_path)
-        self.assert_(file_removed, 'Copied file still exists')
+        self.assertTrue(file_removed, 'Copied file still exists')
         files.remove(TestGFAL2Util.__remote_path)
         files.remove(TestGFAL2Util.__local_path)

--- a/osgtest/tests/test_820_cvmfs.py
+++ b/osgtest/tests/test_820_cvmfs.py
@@ -18,7 +18,7 @@ class TestStopCvmfs(osgunittest.OSGTestCase):
             pass  # tempdir was never created
 
         stdout, _, fail = core.check_system(('cvmfs_config', 'umount'), 'Stop Cvmfs server')
-        self.assert_(stdout.find('FAILED') == -1, fail)
+        self.assertTrue(stdout.find('FAILED') == -1, fail)
 
         files.restore("/etc/fuse.conf", "cvmfs")
         files.restore("/etc/auto.master", "cvmfs")

--- a/osgtest/tests/test_970_java.py
+++ b/osgtest/tests/test_970_java.py
@@ -6,7 +6,7 @@ class TestCleanupJava(osgunittest.OSGTestCase):
 
     def _select_old_alternative(self, config_type):
         java.select_ver(config_type, core.config['java.old-ver'][config_type])
-        self.assert_(java.verify_ver(config_type, core.config['java.old-ver'][config_type]),
+        self.assertTrue(java.verify_ver(config_type, core.config['java.old-ver'][config_type]),
                      'could not select old java version %s' % core.config['java.old-ver'][config_type])
 
     def test_01_revert_java_ver(self):
@@ -16,4 +16,3 @@ class TestCleanupJava(osgunittest.OSGTestCase):
     def test_02_revert_javac_ver(self):
         if java.is_openjdk_devel_installed():
             self._select_old_alternative('javac')
-


### PR DESCRIPTION
A search & replace for Python 3.12 compatibility (where `assert_` was removed). There are some improvements we could make (e.g. `self.assertTrue(result is not None)` could be `self.assertIsNotNone(result)`) once we have more time...