### PR TITLE
Fix capturing stderr output

### DIFF
--- a/osgtest/library/core.py
+++ b/osgtest/library/core.py
@@ -573,8 +573,8 @@ def __run_command(command, use_test_user, a_input, a_stdout, a_stderr, log_outpu
         if type(timeout_signal) == str:
             timeout_signal = getattr(signal, 'SIG' + timeout_signal.upper())
 
-    p = subprocess.Popen(command, stdin=stdin, stdout=subprocess.PIPE,
-                         stderr=subprocess.STDOUT, shell=shell,
+    p = subprocess.Popen(command, stdin=stdin, stdout=a_stdout,
+                         stderr=a_stderr, shell=shell,
                          preexec_fn=preexec_fn)
 
     if timeout is not None:

--- a/osgtest/library/yum.py
+++ b/osgtest/library/yum.py
@@ -44,7 +44,7 @@ def retry_command(command, timeout_seconds=3600):
             break
 
         # Deal with failures that can be retried
-        elif yum_failure_can_be_retried(stdout):
+        elif yum_failure_can_be_retried(stdout + "\n" + stderr):
             time.sleep(30)
             clean()
             core.log_message("Retrying command")

--- a/osgtest/tests/test_060_fetch_crl.py
+++ b/osgtest/tests/test_060_fetch_crl.py
@@ -51,7 +51,7 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         status, stdout, stderr = core.system(command)
         fail = core.diagnose('Run %s in /etc' % 'fetch-crl', command, status, stdout, stderr)
         if status == 1:
-            self.assertTrue(output_is_acceptable(stdout), fail)
+            self.assertTrue(output_is_acceptable(stdout + "\n" + stderr), fail)
         else:
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join('/etc/grid-security/certificates', '*.r[0-9]')))
@@ -68,7 +68,7 @@ class TestFetchCrl(osgunittest.OSGTestCase):
         status, stdout, stderr = core.system(command)
         fail = core.diagnose('Run fetch-crl in temp dir', command, status, stdout, stderr)
         if status == 1:
-            self.assertTrue(output_is_acceptable(stdout), fail)
+            self.assertTrue(output_is_acceptable(stdout + "\n" + stderr), fail)
         else:
             self.assertEquals(status, 0, fail)
         count = len(glob.glob(os.path.join(temp_crl_dir, '*.r[0-9]')))

--- a/osgtest/tests/test_070_munge.py
+++ b/osgtest/tests/test_070_munge.py
@@ -13,6 +13,6 @@ class TestStartMunge(osgunittest.OSGTestCase):
 
         files.preserve(core.config['munge.keyfile'], 'munge')
         command = ('/usr/sbin/create-munge-key', '-f',)
-        stdout, _, fail = core.check_system(command, 'Create munge key')
-        self.assertTrue(stdout.find('error') == -1, fail)
+        stdout, stderr, fail = core.check_system(command, 'Create munge key')
+        self.assertNotIn("error", stdout + "\n" + stderr, fail)
         service.check_start('munge')

--- a/osgtest/tests/test_170_pbs.py
+++ b/osgtest/tests/test_170_pbs.py
@@ -74,8 +74,8 @@ set server acl_host_enable = True
         if not os.path.exists(core.config['torque.pbs-serverdb']):
             command = ('/usr/sbin/pbs_server -d /var/lib/torque -t create -f && '
                        'sleep 10 && /usr/bin/qterm')
-            stdout, _, fail = core.check_system(command, 'create initial pbs serverdb config', shell=True)
-            self.assertTrue(stdout.find('error') == -1, fail)
+            stdout, stderr, fail = core.check_system(command, 'create initial pbs serverdb config', shell=True)
+            self.assertNotIn("error", stdout + "\n" + stderr, fail)
 
         # This gets wiped if we write it before the initial 'service pbs_server create'
         # However, this file needs to be in place before the service is started so we
@@ -110,9 +110,10 @@ set server acl_host_enable = True
         start_time = time.time()
         while (time.time() - start_time) < 600:
             command = ('/usr/bin/qnodes', '-s', core.get_hostname())
-            stdout, _, fail = core.check_system(command, 'Get pbs node info')
-            self.assertTrue(stdout.find('error') == -1, fail)
-            if stdout.find('state = free'):
+            stdout, stderr, fail = core.check_system(command, 'Get pbs node info')
+            output = stdout + "\n" + stderr
+            self.assertNotIn("error", output, fail)
+            if "state = free" in output:
                 core.state['torque.nodes-up'] = True
                 break
         if not core.state['torque.nodes-up']:

--- a/osgtest/tests/test_180_cvmfs.py
+++ b/osgtest/tests/test_180_cvmfs.py
@@ -57,6 +57,6 @@ class TestStartCvmfs(osgunittest.OSGTestCase):
         setup_automount()
         setup_cvmfs()
 
-        stdout, _, fail = core.check_system(('service', 'autofs', 'restart'), 'Start cvmfs server')
-        self.assertFalse("FAILED" in stdout, fail)
+        stdout, stderr, fail = core.check_system(('service', 'autofs', 'restart'), 'Start cvmfs server')
+        self.assertNotIn("FAILED", stdout + "\n" + stderr, fail)
         core.state['cvmfs.started-server'] = True

--- a/osgtest/tests/test_820_cvmfs.py
+++ b/osgtest/tests/test_820_cvmfs.py
@@ -17,8 +17,8 @@ class TestStopCvmfs(osgunittest.OSGTestCase):
         except KeyError:
             pass  # tempdir was never created
 
-        stdout, _, fail = core.check_system(('cvmfs_config', 'umount'), 'Stop Cvmfs server')
-        self.assertTrue(stdout.find('FAILED') == -1, fail)
+        stdout, stderr, fail = core.check_system(('cvmfs_config', 'umount'), 'Stop Cvmfs server')
+        self.assertNotIn("FAILED", stdout + "\n" + stderr, fail)
 
         files.restore("/etc/fuse.conf", "cvmfs")
         files.restore("/etc/auto.master", "cvmfs")


### PR DESCRIPTION
Fixes a long-standing bug in `core.__run_command()` where stderr was always redirected to stdout, causing the `STDERR` sections in logs to always be empty.  Since some tests search through output looking for error messages, combine stdout and stderr explicitly in those tests.

https://osg-sw-submit.chtc.wisc.edu/tests/20251009-1714/results.html
