### PR TITLE
Turn off the safety check that prevents TPCs from local or private addresses

### DIFF
--- a/osgtest/tests/test_158_xrootd_tpc.py
+++ b/osgtest/tests/test_158_xrootd_tpc.py
@@ -15,6 +15,8 @@ all.adminpath /var/spool/xrootd
 all.pidpath /var/run/xrootd
 set resourcename = VDTTEST
 set rootdir = {xrootd.ROOTDIR}
+tpc.allow local
+tpc.allow private
 continue /etc/xrootd/config.d/
 """
 


### PR DESCRIPTION
We're running in a VM with NAT networking, so this is our situation.

Tests: https://osgsw-ap2000.chtc.wisc.edu/tests/20260710-1551/packages.html