### PR TITLE
Stop using distutils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ TARBALL_DIR := $(PACKAGE)-$(VERSION)
 TARBALL_NAME := $(PACKAGE)-$(VERSION).tar.gz
 UPSTREAM := /p/vdt/public/html/upstream
 UPSTREAM_DIR := $(UPSTREAM)/$(PACKAGE)/$(VERSION)
-INSTALL_PYTHON_DIR := $(shell $(PYTHON) -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')
+INSTALL_PYTHON_DIR := $(shell $(PYTHON) -c 'from sysconfig import get_path; print(get_path("purelib"))')
 
 
 # ------------------------------------------------------------------------------

--- a/osg-test
+++ b/osg-test
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from distutils.sysconfig import get_python_lib
 from optparse import OptionParser
 import configparser as ConfigParser
 import os


### PR DESCRIPTION
It was removed in Python 3.12. osg-test itself doesn't even use it, it's just a leftover import. We do use it in the Makefile (though I don't know if we use the Makefile).